### PR TITLE
kubeconfig secret name check

### DIFF
--- a/api/v1alpha1/operatorpipeline_types.go
+++ b/api/v1alpha1/operatorpipeline_types.go
@@ -30,6 +30,9 @@ type OperatorPipelineSpec struct {
 
 	// OperatorPipelinesRelease is the Operator Pipelines release (version) to install.
 	OperatorPipelinesRelease string `json:"operatorPipelinesRelease,omitempty"`
+
+	// KubeconfigSecretName is the name of the secret containing the kubeconfig that will be used by the pipeline.
+	KubeconfigSecretName string `json:"kubeconfigSecretName,omitempty"`
 }
 
 // OperatorPipelineStatus defines the observed state of OperatorPipeline

--- a/config/crd/bases/certification.redhat.com_operatorpipelines.yaml
+++ b/config/crd/bases/certification.redhat.com_operatorpipelines.yaml
@@ -36,6 +36,10 @@ spec:
           spec:
             description: OperatorPipelineSpec defines the desired state of OperatorPipeline
             properties:
+              kubeconfigSecretName:
+                description: KubeconfigSecretName is the name of the secret containing
+                  the kubeconfig that will be used by the pipeline.
+                type: string
               openShiftPipelineVersion:
                 description: OpenShiftPipelineVersion is the version of the OpenShift
                   Pipelines Operator to install.


### PR DESCRIPTION
This was meant to address #4 
* Added a kubeconfigSecretName field to the CR to specify the name of the secret containing the kubeconfig to be used by the pipeline
* Added some validation (some of it can be removed looking for comments)
* The same pattern will apply to the other two secrets i.e. github api and pyxis (Will do #8 and #9 based on feedback on this one)
* The logging may be inconsistent left it to be addressed in #15 