### PR TITLE
adding in support for git hub token

### DIFF
--- a/api/v1alpha1/operatorpipeline_types.go
+++ b/api/v1alpha1/operatorpipeline_types.go
@@ -31,6 +31,10 @@ type OperatorPipelineSpec struct {
 	// OperatorPipelinesRelease is the Operator Pipelines release (version) to install.
 	OperatorPipelinesRelease string `json:"operatorPipelinesRelease,omitempty"`
 
+	// GitHubSecretName is the name of the secret containing the GitHub Token that will be used by the pipeline.
+	//+kubebuilder:validation:Optional
+	GitHubSecretName string `json:"gitHubSecretName,omitempty"`
+
 	// KubeconfigSecretName is the name of the secret containing the kubeconfig that will be used by the pipeline.
 	KubeconfigSecretName string `json:"kubeconfigSecretName,omitempty"`
 }

--- a/config/crd/bases/certification.redhat.com_operatorpipelines.yaml
+++ b/config/crd/bases/certification.redhat.com_operatorpipelines.yaml
@@ -36,6 +36,10 @@ spec:
           spec:
             description: OperatorPipelineSpec defines the desired state of OperatorPipeline
             properties:
+              gitHubSecretName:
+                description: GitHubSecretName is the name of the secret containing
+                  the GitHub Token that will be used by the pipeline.
+                type: string
               kubeconfigSecretName:
                 description: KubeconfigSecretName is the name of the secret containing
                   the kubeconfig that will be used by the pipeline.

--- a/config/samples/certification_v1alpha1_operatorpipeline.yaml
+++ b/config/samples/certification_v1alpha1_operatorpipeline.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   openShiftPipelineVersion: v1.5.0
   operatorPipelinesRelease: main
+  gitHubSecretName: "github-api-token"


### PR DESCRIPTION
Fixes: #8 

Adding in `gitHubSecretName` to OperatorPipeline spec, which is optional so that the cluster admin can overwrite this value if they created the secret with a different name. Also, validate that this GH secret exists in the cluster.
