### PR TITLE
uncommenting vendor director in ignore file so it doesn't get checked in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@ bin/
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Dependency directories
+vendor/
 
 # editor and IDE paraphernalia
 .idea


### PR DESCRIPTION
Updating the ignore file so the vendor director doesn't get accidentally checked in.

Signed-off-by: Adam D. Cornett <adc@redhat.com>