### PR TITLE
reconcile pyxis api secret

### DIFF
--- a/api/v1alpha1/operatorpipeline_types.go
+++ b/api/v1alpha1/operatorpipeline_types.go
@@ -33,6 +33,9 @@ type OperatorPipelineSpec struct {
 
 	// KubeconfigSecretName is the name of the secret containing the kubeconfig that will be used by the pipeline.
 	KubeconfigSecretName string `json:"kubeconfigSecretName,omitempty"`
+	
+	// The name of the secret containing the pyxis api secret expected by the pipeline
+	PyxisApiSecretName string `json:"pyxisApiSecretName,omitempty"`
 }
 
 // OperatorPipelineStatus defines the observed state of OperatorPipeline

--- a/config/crd/bases/certification.redhat.com_operatorpipelines.yaml
+++ b/config/crd/bases/certification.redhat.com_operatorpipelines.yaml
@@ -48,6 +48,10 @@ spec:
                 description: OperatorPipelinesRelease is the Operator Pipelines release
                   (version) to install.
                 type: string
+              pyxisApiSecretName:
+                description: The name of the secret containing the pyxis api secret
+                  expected by the pipeline
+                type: string
             type: object
           status:
             description: OperatorPipelineStatus defines the observed state of OperatorPipeline

--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -31,6 +31,7 @@ const (
 	KUBECONFIG_SECRET = "kubeconfig"
 	GITHUB_API_SECRET = "github-api-token"
 	PYXIS_API_SECRET  = "pyxis-api-secret"
+	PYXIS_API_KEY     = "pyxis_api_key"
 )
 
 // reconcileKubeConfigSecret will ensure that the kubeconfig Secret is present and up to date.
@@ -96,18 +97,46 @@ func (r *OperatorPipelineReconciler) reconcileGitHubAPISecret(meta metav1.Object
 
 // reconcilePyxisAPISecret will ensure that the Pyxis API Secret is present and up to date.
 func (r *OperatorPipelineReconciler) reconcilePyxisAPISecret(meta metav1.ObjectMeta) error {
+	pipelineName := types.NamespacedName{
+		Namespace: meta.Namespace,
+		Name:      meta.Name,
+	}
+	pipeline := &certv1alpha1.OperatorPipeline{}
+	err := r.Client.Get(context.TODO(), pipelineName, pipeline)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.Info("pipeline resource not found. Ignoring since object must be deleted")
+			return nil
+		}
+		log.Error(err, "unable to retrieve pipeline resource in namespace "+meta.Namespace)
+		return err
+	}
+	var secretName = PYXIS_API_SECRET
+	if pipeline.Spec.PyxisApiSecretName != "" {
+		secretName = pipeline.Spec.PyxisApiSecretName
+	}
 	key := types.NamespacedName{
 		Namespace: meta.Namespace,
-		Name:      PYXIS_API_SECRET,
+		Name:      secretName,
 	}
-
 	secret := newSecret(key)
-	if IsObjectFound(r.Client, key, secret) {
-		log.Info("existing pyxis api secret found")
-		return nil // Existing Secret found, do nothing...
+	if !IsObjectFound(r.Client, key, secret) {
+		err := errors.New(fmt.Sprintf("an existing secret named %s was not found in namespace %s", secretName, meta.Namespace))
+		log.Error(err, fmt.Sprintf("unable to reconcile %s in namespace %s", secretName, meta.Namespace))
+		return err
 	}
-
-	return errors.New("pyxis api secret not found")
+	log.Info(fmt.Sprintf("existing %s secret found in namespace %s", secretName, meta.Namespace))
+	pyxisApiSecret := &corev1.Secret{}
+	if r.Client.Get(context.TODO(), key, pyxisApiSecret) != nil {
+		log.Error(err, fmt.Sprintf("unable to get the %s secret", secretName))
+		return err
+	}
+	if pyxisApiSecret.Data[PYXIS_API_SECRET] == nil || len(pyxisApiSecret.Data[PYXIS_API_SECRET]) == 0 {
+		err = errors.New(fmt.Sprintf("the kubeconfig key in %s is empty!", secretName))
+		log.Error(err, fmt.Sprintf("The %s secret does not contain the expected key", secretName))
+		return err
+	}
+	return nil // Existing Secret found, do nothing...
 }
 
 // newSecret will create and return a new Secret instance using the given Name/Namespace.
@@ -118,4 +147,22 @@ func newSecret(key types.NamespacedName) *corev1.Secret {
 			Namespace: key.Namespace,
 		},
 	}
+}
+
+func (r *OperatorPipelineReconciler) getPipelineInstance(meta metav1.ObjectMeta) (*certv1alpha1.OperatorPipeline, error) {
+	pipeline := types.NamespacedName{
+		Namespace: meta.Namespace,
+		Name:      meta.Name,
+	}
+	pipelineInstance := &certv1alpha1.OperatorPipeline{}
+	err := r.Client.Get(context.TODO(), pipeline, pipelineInstance)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.Info("pipeline resource not found. Ignoring since object must be deleted")
+			return nil, nil
+		}
+		log.Error(err, "unable to retrieve pipeline resource in namespace "+meta.Namespace)
+		return nil, err
+	}
+	return pipelineInstance, nil
 }


### PR DESCRIPTION
Addresses #9 

The pyxis api secret name can optionally be configured via the cr

This is going to have a bunch of repeated code to be addressed in #24 