### PR TITLE
Updating `namePrefix` and `namespace` so operator can be installed

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: operator-certification-operator-system
+namespace: certification-operator-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: operator-certification-operator-
+namePrefix: certification-operator-
 
 # Labels to add to all resources and selectors.
 #commonLabels:


### PR DESCRIPTION
Fixes: #25 

This addressed the length constraints of 63 max characters for `metadata.name` of the service. 

Signed-off-by: Adam D. Cornett <adc@redhat.com>