### PR TITLE
initial operator bundle and build

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -26,21 +26,21 @@ jobs:
         tags: ${{ github.sha }}
         build-args: |
           quay_expiration=1w
-          release_tag=${{ env.RELEASE_TAG }}-alpha+${{ github.sha }}
+          release_tag=${{ env.RELEASE_TAG }}-alpha
         dockerfiles: |
           ./Dockerfile
 
-  #  - name: Build Bundle Image
-  #    id: build-bundle-image
-  #    uses: redhat-actions/buildah-build@v2
-  #    with:
-  #      image: ${{ env.IMAGE_REGISTRY }}/operator-certification-operator-bundle
-  #      tags: ${{ github.sha }}
-  #      build-args: |
-  #        quay_expiration=1w
-  #        release_tag=${{ env.RELEASE_TAG }}-alpha+${{ github.sha }}
-  #      dockerfiles: |
-  #        ./bundle.Dockerfile
+    - name: Build Bundle Image
+      id: build-bundle-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_REGISTRY }}/operator-certification-operator-bundle
+        tags: ${{ github.sha }}
+        build-args: |
+          quay_expiration=1w
+          release_tag=${{ env.RELEASE_TAG }}-alpha
+        dockerfiles: |
+          ./bundle.Dockerfile
 
     - name: Push Operator Image
       id: push-operator-image
@@ -52,15 +52,15 @@ jobs:
         username: ${{ secrets.REGISTRY_USER }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
     
-  #  - name: Push Bundle Image
-  #    id: push-bundle-image
-  #    uses: redhat-actions/push-to-registry@v2
-  #    with:
-  #      image: operator-certification-operator-bundle
-  #      tags: ${{ steps.build-bundle-image.outputs.tags }}
-  #      registry: ${{ env.IMAGE_REGISTRY }}
-  #      username: ${{ secrets.REGISTRY_USER }}
-  #      password: ${{ secrets.REGISTRY_PASSWORD }}
+    - name: Push Bundle Image
+      id: push-bundle-image
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: operator-certification-operator-bundle
+        tags: ${{ steps.build-bundle-image.outputs.tags }}
+        registry: ${{ env.IMAGE_REGISTRY }}
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
 
     - run: echo "Operator Image pushed to ${{ steps.push-operator-image.outputs.registry-paths }}"
-  #  - run: echo "Bundle Image pushed to ${{ steps.push-bundle-image.outputs.registry-paths }}"
+    - run: echo "Bundle Image pushed to ${{ steps.push-bundle-image.outputs.registry-paths }}"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,16 +27,16 @@ jobs:
         dockerfiles: |
           ./Dockerfile
 
-  #  - name: Build Bundle Image
-  #    id: build-bundle-image
-  #    uses: redhat-actions/buildah-build@v2
-  #    with:
-  #      image: ${{ env.IMAGE_REGISTRY }}/operator-certification-operator-bundle
-  #      tags: ${{ env.RELEASE_TAG }}
-  #      build-args: |
-  #        release_tag=${{ env.RELEASE_TAG }}
-  #      dockerfiles: |
-  #        ./bundle.Dockerfile
+    - name: Build Bundle Image
+      id: build-bundle-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_REGISTRY }}/operator-certification-operator-bundle
+        tags: ${{ env.RELEASE_TAG }}
+        build-args: |
+          release_tag=${{ env.RELEASE_TAG }}
+        dockerfiles: |
+          ./bundle.Dockerfile
 
     - name: Push Operator Image
       id: push-operator-image
@@ -48,15 +48,15 @@ jobs:
         username: ${{ secrets.REGISTRY_USER }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
     
-  #  - name: Push Bundle Image
-  #    id: push-bundle-image
-  #    uses: redhat-actions/push-to-registry@v2
-  #    with:
-  #      image: operator-certification-operator-bundle
-  #      tags: ${{ steps.build-bundle-image.outputs.tags }}
-  #      registry: ${{ env.IMAGE_REGISTRY }}
-  #      username: ${{ secrets.REGISTRY_USER }}
-  #      password: ${{ secrets.REGISTRY_PASSWORD }}
+    - name: Push Bundle Image
+      id: push-bundle-image
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: operator-certification-operator-bundle
+        tags: ${{ steps.build-bundle-image.outputs.tags }}
+        registry: ${{ env.IMAGE_REGISTRY }}
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
 
     - run: echo "Operator Image pushed to ${{ steps.push-operator-image.outputs.registry-paths }}"
-  #  - run: echo "Bundle Image pushed to ${{ steps.push-bundle-image.outputs.registry-paths }}"
+    - run: echo "Bundle Image pushed to ${{ steps.push-bundle-image.outputs.registry-paths }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,34 @@
+ARG quay_expiration=never
+ARG release_tag=0.0.0
+
 # Build the manager binary
 FROM golang:1.16 as builder
 
+ARG release_tag
+
+# Copy the go source
+COPY . /workspace
+
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
-
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN make build RELEASE_TAG=${release_tag}
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
+
+ARG quay_expiration
+
+# Define that tags should expire after 1 week. This should not apply to versioned releases.
+LABEL quay.expires-after=${quay_expiration}
+
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,0 +1,43 @@
+ARG quay_expiration=never
+ARG release_tag=0.0.0
+
+FROM quay.io/operator-framework/operator-sdk:v1.14.0 as builder
+
+ARG release_tag
+# Copy the go source
+COPY . /workspace
+
+WORKDIR /workspace
+
+RUN microdnf install -y \
+      gcc \
+      git
+
+# Generate versioned manifests. when manifests exists this will set the version provided.
+RUN make bundle RELEASE_TAG=${release_tag}
+
+FROM scratch
+
+ARG quay_expiration
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=operator-certification-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.13.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Define that tags should expire after 1 week. This should not apply to versioned releases.
+LABEL quay.expires-after=${quay_expiration}
+
+# Copy files to locations specified by labels.
+COPY --from=builder /workspace/bundle/manifests /manifests/
+COPY --from=builder /workspace/bundle/metadata /metadata/
+COPY --from=builder /workspace/bundle/tests/scorecard /tests/scorecard/

--- a/bundle/manifests/certification-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/certification-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    control-plane: controller-manager
+  name: certification-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/bundle/manifests/certification-operator-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/certification-operator-manager-config_v1_configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: ef59679f.redhat.com
+kind: ConfigMap
+metadata:
+  name: certification-operator-manager-config

--- a/bundle/manifests/certification-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/certification-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: certification-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/bundle/manifests/certification.redhat.com_operatorpipelines.yaml
+++ b/bundle/manifests/certification.redhat.com_operatorpipelines.yaml
@@ -1,0 +1,59 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: operatorpipelines.certification.redhat.com
+spec:
+  group: certification.redhat.com
+  names:
+    kind: OperatorPipeline
+    listKind: OperatorPipelineList
+    plural: operatorpipelines
+    singular: operatorpipeline
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OperatorPipeline is the Schema for the operatorpipelines API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OperatorPipelineSpec defines the desired state of OperatorPipeline
+            properties:
+              openShiftPipelineVersion:
+                description: OpenShiftPipelineVersion is the version of the OpenShift
+                  Pipelines Operator to install.
+                type: string
+              operatorPipelinesRelease:
+                description: OperatorPipelinesRelease is the Operator Pipelines release
+                  (version) to install.
+                type: string
+            type: object
+          status:
+            description: OperatorPipelineStatus defines the observed state of OperatorPipeline
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/manifests/operator-certification-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator-certification-operator.clusterserviceversion.yaml
@@ -1,0 +1,239 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "certification.redhat.com/v1alpha1",
+          "kind": "OperatorPipeline",
+          "metadata": {
+            "name": "operatorpipeline-sample"
+          },
+          "spec": {
+            "openShiftPipelineVersion": "v1.5.0",
+            "operatorPipelinesRelease": "main"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    operators.operatorframework.io/builder: operator-sdk-v1.13.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+  name: operator-certification-operator.v0.0.0-alpha
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: OperatorPipeline is the Schema for the operatorpipelines API
+      displayName: Operator Pipeline
+      kind: OperatorPipeline
+      name: operatorpipelines.certification.redhat.com
+      version: v1alpha1
+  description: An Operator for setting up Operator Certification CI Pipeline
+  displayName: Operator Certification Operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - certification.redhat.com
+          resources:
+          - operatorpipelines
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - certification.redhat.com
+          resources:
+          - operatorpipelines/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - certification.redhat.com
+          resources:
+          - operatorpipelines/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreamimports
+          verbs:
+          - create
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - subscriptions
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: certification-operator-controller-manager
+      deployments:
+      - name: certification-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources: {}
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                command:
+                - /manager
+                image: quay.io/opdev/operator-certification-operator:09f54622a8707ebc3e94aaef9a8781cf9bf6cc6d
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 100Mi
+                  requests:
+                    cpu: 100m
+                    memory: 20Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: certification-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: certification-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - certification
+  - pipeline
+  links:
+  - name: Operator Certification Operator
+    url: https://github.com/redhat-openshift-ecosystem/operator-certification-operator
+  maintainers:
+  - email: jomckenz@redhat.com
+    name: jomkz
+  maturity: alpha
+  provider:
+    name: Redhat
+    url: https://redhat.com
+  version: 0.0.0-alpha

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,0 +1,14 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: operator-certification-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.13.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -1,50 +1,70 @@
-- op: add
-  path: /stages/0/tests/-
-  value:
-    entrypoint:
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.14.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
     - scorecard-test
     - olm-bundle-validation
     image: quay.io/operator-framework/scorecard-test:v1.14.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
-- op: add
-  path: /stages/0/tests/-
-  value:
-    entrypoint:
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
     image: quay.io/operator-framework/scorecard-test:v1.14.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
-- op: add
-  path: /stages/0/tests/-
-  value:
-    entrypoint:
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
     image: quay.io/operator-framework/scorecard-test:v1.14.0
     labels:
       suite: olm
       test: olm-crds-have-resources-test
-- op: add
-  path: /stages/0/tests/-
-  value:
-    entrypoint:
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
     image: quay.io/operator-framework/scorecard-test:v1.14.0
     labels:
       suite: olm
       test: olm-spec-descriptors-test
-- op: add
-  path: /stages/0/tests/-
-  value:
-    entrypoint:
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
     - scorecard-test
     - olm-status-descriptors
     image: quay.io/operator-framework/scorecard-test:v1.14.0
     labels:
       suite: olm
       test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
-  newTag: latest
+  newName: quay.io/opdev/operator-certification-operator
+  newTag: 09f54622a8707ebc3e94aaef9a8781cf9bf6cc6d

--- a/config/manifests/bases/operator-certification-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/operator-certification-operator.clusterserviceversion.yaml
@@ -1,0 +1,50 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Basic Install
+  name: operator-certification-operator.v0.0.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: OperatorPipeline is the Schema for the operatorpipelines API
+      displayName: Operator Pipeline
+      kind: OperatorPipeline
+      name: operatorpipelines.certification.redhat.com
+      version: v1alpha1
+  description: An Operator for setting up Operator Certification CI Pipeline
+  displayName: Operator Certification Operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      deployments: null
+    strategy: ""
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - certification
+  - pipeline
+  links:
+  - name: Operator Certification Operator
+    url: https://github.com/redhat-openshift-ecosystem/operator-certification-operator
+  maintainers:
+  - email: jomckenz@redhat.com
+    name: jomkz
+  maturity: alpha
+  provider:
+    name: Redhat
+    url: https://redhat.com
+  version: 0.0.0
+  minKubeVersion: 1.21.0

--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.11.0
+    image: quay.io/operator-framework/scorecard-test:v1.14.0
     labels:
       suite: basic
       test: basic-check-spec-test


### PR DESCRIPTION
Adding a CSV and bundle manifests generated by make bundle.
Adding builds for the bundle in GH Actions.

When building the bundle, the Dockerfile will run make bundle.
what this does, when bundle files already exist, is overrides the version of the controller image so that it is synced with the recently-built snapshot or release.

Fixes: #12

Signed-off-by: Igor Troyanovsky <itroyano@redhat.com>