### PR TITLE
adding in operator binary to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 bin/
+operator-certification-operator
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
Small update to the git ignore to not include the operator binary in the repo.

Signed-off-by: Adam D. Cornett <adc@redhat.com>