### PR TITLE
adding additional error handling to not block additional reconciliation

### DIFF
--- a/controllers/dependencies.go
+++ b/controllers/dependencies.go
@@ -2,21 +2,20 @@ package controllers
 
 import (
 	"context"
-
+	"fmt"
 	"os"
-
 	"path/filepath"
 
-	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5"
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	OPERATOR_PIPELINES_REPO = "https://github.com/redhat-openshift-ecosystem/operator-pipelines.git"
-	REPO_CLONE_PATH         = "/tmp/operator-pipelines/"
 	PIPELINE_MANIFESTS_PATH = "ansible/roles/operator-pipeline/templates/openshift/pipelines"
 	TASK_MANIFESTS_PATH     = "ansible/roles/operator-pipeline/templates/openshift/tasks"
 )
@@ -27,10 +26,15 @@ func (r *OperatorPipelineReconciler) reconcilePipelineDependencies(meta metav1.O
 	// yaml manifests that need to be applied beforehand
 	// ref: https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/ci-pipeline.md#step-6---install-the-certification-pipeline-and-dependencies-into-the-cluster
 
-	_, err := git.PlainClone(REPO_CLONE_PATH, false, &git.CloneOptions{
+	// creating a tmp director so that each reconcile gets a new directory in case the defer does not execute properly
+	tmpRepoClonePath, _ := os.MkdirTemp("", "operator-pipelines-*")
+
+	_, err := git.PlainClone(tmpRepoClonePath, false, &git.CloneOptions{
 		URL: OPERATOR_PIPELINES_REPO,
 	})
-	defer r.removePipelineDependencyFiles(REPO_CLONE_PATH)
+
+	defer os.RemoveAll(tmpRepoClonePath)
+
 	if err != nil {
 		log.Error(err, "Couldn't clone the repository for operator-pipelines")
 		return err
@@ -40,28 +44,23 @@ func (r *OperatorPipelineReconciler) reconcilePipelineDependencies(meta metav1.O
 	for _, path := range paths {
 
 		// base repository root + specific yaml manifest directory (pipelines or tasks)
-		root := REPO_CLONE_PATH + path
+		root := filepath.Join(tmpRepoClonePath, path)
 
-		// walking through the each directory (pipelines or tasks)
+		// walking through each directory (pipelines or tasks)
 		err = filepath.Walk(root, func(filePath string, info os.FileInfo, err error) error {
 
 			// For each file NOT directories
 			if !info.IsDir() {
-				var pipeline tekton.Pipeline
-				var task tekton.Task
 
 				// apply pipeline yaml manifests
 				if path == PIPELINE_MANIFESTS_PATH {
-					if errors := r.applyManifests(filePath, meta.Namespace, &pipeline); errors != nil {
-						log.Error(errors, "Couldn't apply pipeline manifest")
-						return errors
+					if errs := r.applyPipelineManifests(filePath, meta); errs != nil {
+						return errs
 					}
-
 					// or apply tasks manifests
 				} else {
-					if errors := r.applyManifests(filePath, meta.Namespace, &task); errors != nil {
-						log.Error(errors, "Couldn't apply task manifest")
-						return errors
+					if errs := r.applyTaskManifests(filePath, meta); errs != nil {
+						return errs
 					}
 				}
 			}
@@ -72,34 +71,83 @@ func (r *OperatorPipelineReconciler) reconcilePipelineDependencies(meta metav1.O
 			return err
 		}
 	}
+
 	return nil
 }
 
-func (r *OperatorPipelineReconciler) removePipelineDependencyFiles(filePath string) error {
-	if err := os.RemoveAll(filePath); err != nil {
-		log.Error(err, "Couldn't remove operator-pipelines directory")
-		return err
-	}
-	return nil
-}
-
-func (r *OperatorPipelineReconciler) applyManifests(fileName string, Namespace string, obj client.Object) error {
+func (r *OperatorPipelineReconciler) applyPipelineManifests(fileName string, meta metav1.ObjectMeta) error {
 
 	b, err := os.ReadFile(fileName)
 	if err != nil {
-		log.Error(err, "Couldn't read manifest file")
+		log.Error(err, fmt.Sprintf("Couldn't read manifest file for: %s", fileName))
 		return err
 	}
 
-	if err = yamlutil.Unmarshal(b, &obj); err != nil {
-		log.Error(err, "Couldn't unmarshall yaml file")
+	pipeline := new(tekton.Pipeline)
+
+	if err = yamlutil.Unmarshal(b, pipeline); err != nil {
+		log.Error(err, fmt.Sprintf("Couldn't unmarshall yaml file for: %s", fileName))
 		return err
 	}
 
-	obj.SetNamespace(Namespace)
-	if err = r.Client.Create(context.Background(), obj); err != nil {
-		log.Error(err, "Couldn't create resource")
+	pipeline.SetNamespace(meta.Namespace)
+	err = r.Get(context.Background(), types.NamespacedName{Name: pipeline.Name, Namespace: pipeline.Namespace}, pipeline)
+
+	if len(pipeline.ObjectMeta.UID) > 0 {
+		if err := r.Client.Update(context.Background(), pipeline); err != nil {
+			log.Error(err, fmt.Sprintf("failed to update pipeline resource for file: %s", fileName))
+			return err
+		}
+	}
+
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+
+		if err := r.Client.Create(context.Background(), pipeline); err != nil {
+			log.Error(err, fmt.Sprintf("failed to create pipeline resource for file: %s", fileName))
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *OperatorPipelineReconciler) applyTaskManifests(fileName string, meta metav1.ObjectMeta) error {
+
+	b, err := os.ReadFile(fileName)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Couldn't read manifest file for: %s", fileName))
 		return err
+	}
+
+	task := new(tekton.Task)
+
+	if err = yamlutil.Unmarshal(b, task); err != nil {
+		log.Error(err, fmt.Sprintf("Couldn't unmarshall yaml file for: %s", fileName))
+		return err
+	}
+
+	task.SetNamespace(meta.Namespace)
+	err = r.Get(context.Background(), types.NamespacedName{Name: task.Name, Namespace: task.Namespace}, task)
+
+	if len(task.ObjectMeta.UID) > 0 {
+		if err := r.Client.Update(context.Background(), task); err != nil {
+			log.Error(err, fmt.Sprintf("failed to create task resource for file: %s", fileName))
+			return err
+		}
+	}
+
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+
+		if err := r.Client.Create(context.Background(), task); err != nil {
+			log.Error(err, fmt.Sprintf("failed to update task resource for file: %s", fileName))
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
- Fixes: #31 

- Calling removePipelineDependencyFiles() before each clone to make sure we always get latest code from the pipelines repo.
- Changing var name to `errs` to avoid package level collisions with the `errors` package.
- Adding separate apply() methods for pipeline/task so we can check if they exist and update them, to prevent errors when they already exist in the cluster. This also helps the operator apply new pipelines/tasks to the cluster when the pipelines repo gets updated. 

Signed-off-by: Adam D. Cornett <adc@redhat.com>