### PR TITLE
adding checks for pinning and private registry secrets

### DIFF
--- a/api/v1alpha1/operatorpipeline_types.go
+++ b/api/v1alpha1/operatorpipeline_types.go
@@ -40,6 +40,12 @@ type OperatorPipelineSpec struct {
 
 	// The name of the secret containing the pyxis api secret expected by the pipeline
 	PyxisSecretName string `json:"pyxisSecretName,omitempty"`
+
+	// The name of the secret containing the docker registry credentials secret expected by the pipeline
+	DockerRegistrySecretName string `json:"dockerRegistrySecretName,omitempty"`
+
+	// The name of the secret containing the github ssh secret expected by the pipeline
+	GithubSSHSecretName string `json:"githubSSHSecretName,omitempty"`
 }
 
 // OperatorPipelineStatus defines the observed state of OperatorPipeline

--- a/bundle/manifests/certification.redhat.com_operatorpipelines.yaml
+++ b/bundle/manifests/certification.redhat.com_operatorpipelines.yaml
@@ -34,9 +34,17 @@ spec:
           spec:
             description: OperatorPipelineSpec defines the desired state of OperatorPipeline
             properties:
+              dockerRegistrySecretName:
+                description: The name of the secret containing the docker registry
+                  credentials secret expected by the pipeline
+                type: string
               gitHubSecretName:
                 description: GitHubSecretName is the name of the secret containing
                   the GitHub Token that will be used by the pipeline.
+                type: string
+              githubSSHSecretName:
+                description: The name of the secret containing the github ssh secret
+                  expected by the pipeline
                 type: string
               kubeconfigSecretName:
                 description: KubeconfigSecretName is the name of the secret containing

--- a/config/crd/bases/certification.redhat.com_operatorpipelines.yaml
+++ b/config/crd/bases/certification.redhat.com_operatorpipelines.yaml
@@ -36,9 +36,17 @@ spec:
           spec:
             description: OperatorPipelineSpec defines the desired state of OperatorPipeline
             properties:
+              dockerRegistrySecretName:
+                description: The name of the secret containing the docker registry
+                  credentials secret expected by the pipeline
+                type: string
               gitHubSecretName:
                 description: GitHubSecretName is the name of the secret containing
                   the GitHub Token that will be used by the pipeline.
+                type: string
+              githubSSHSecretName:
+                description: The name of the secret containing the github ssh secret
+                  expected by the pipeline
                 type: string
               kubeconfigSecretName:
                 description: KubeconfigSecretName is the name of the secret containing

--- a/controllers/resource.go
+++ b/controllers/resource.go
@@ -68,6 +68,14 @@ func (r *OperatorPipelineReconciler) reconcileResources(ctx context.Context, pip
 		return err
 	}
 
+	if err := r.ensureDockerRegistrySecret(ctx, pipeline.ObjectMeta); err != nil {
+		log.Info("Docker Registry Secret not present or correct. Create it to use a private repository.")
+	}
+
+	if err := r.ensureGithubSSHSecret(ctx, pipeline.ObjectMeta); err != nil {
+		log.Info("Github SSH Secret not present or correct. Create it to enable digest pinning.")
+	}
+
 	if err := r.reconcileCertifiedImageStream(ctx, pipeline.ObjectMeta); err != nil {
 		return err
 	}

--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -28,14 +28,18 @@ import (
 )
 
 const (
-	defaultKubeconfigSecretName    = "kubeconfig"
-	defaultKubeconfigSecretKeyName = "kubeconfig"
-	kubeConfigSecretAvailable      = "KubeConfigSecretAvailable"
-	defaultGithubApiSecretName     = "github-api-token"
-	defaultGithubApiSecretKeyName  = "GITHUB_TOKEN"
-	gitHubSecretAvailable          = "GithubSecretAvailable"
-	defaultPyxisApiSecretName      = "pyxis-api-secret"
-	defaultPyxisApiSecretKeyName   = "pyxis_api_key"
+	defaultKubeconfigSecretName        = "kubeconfig"
+	defaultKubeconfigSecretKeyName     = "kubeconfig"
+	kubeConfigSecretAvailable          = "KubeConfigSecretAvailable"
+	defaultGithubApiSecretName         = "github-api-token"
+	defaultGithubApiSecretKeyName      = "GITHUB_TOKEN"
+	gitHubSecretAvailable              = "GithubSecretAvailable"
+	defaultPyxisApiSecretName          = "pyxis-api-secret"
+	defaultPyxisApiSecretKeyName       = "pyxis_api_key"
+	defaultDockerRegistrySecretName    = "registry-dockerconfig-secret"
+	defaultDockerRegistrySecretKeyName = "docker-username"
+	defaultGithubSSHSecretName         = "github-ssh-credentials"
+	defaultGithubSSHSecretKeyName      = "id_rsa"
 )
 
 // ensureKubeConfigSecret will ensure that the kubeconfig Secret is present and up to date.
@@ -126,6 +130,34 @@ func (r *OperatorPipelineReconciler) ensurePyxisAPISecret(ctx context.Context, m
 		secretName = operatorPipeline.Spec.PyxisSecretName
 	}
 	return r.ensureSecret(ctx, secretName, defaultPyxisApiSecretKeyName, meta)
+}
+
+// ensureDockerRegistrySecret will ensure that the Docker Registry Credentials Secret is present and up to date.
+func (r *OperatorPipelineReconciler) ensureDockerRegistrySecret(ctx context.Context, meta metav1.ObjectMeta) error {
+	operatorPipeline, err := r.getPipeline(ctx, meta)
+	if err != nil {
+		log.Error(err, "unable to resolve docker registry credentials secret for %s in %s", meta.Name, meta.Namespace)
+		return err
+	}
+	secretName := defaultDockerRegistrySecretName
+	if operatorPipeline.Spec.DockerRegistrySecretName != "" {
+		secretName = operatorPipeline.Spec.DockerRegistrySecretName
+	}
+	return r.ensureSecret(ctx, secretName, defaultDockerRegistrySecretKeyName, meta)
+}
+
+// ensureGithubSSHSecret will ensure that the Github SSH Secret is present and up to date.
+func (r *OperatorPipelineReconciler) ensureGithubSSHSecret(ctx context.Context, meta metav1.ObjectMeta) error {
+	operatorPipeline, err := r.getPipeline(ctx, meta)
+	if err != nil {
+		log.Error(err, "unable to resolve github ssh secret for %s in %s", meta.Name, meta.Namespace)
+		return err
+	}
+	secretName := defaultGithubSSHSecretName
+	if operatorPipeline.Spec.GithubSSHSecretName != "" {
+		secretName = operatorPipeline.Spec.GithubSSHSecretName
+	}
+	return r.ensureSecret(ctx, secretName, defaultGithubSSHSecretKeyName, meta)
 }
 
 // ensureSecret will ensure that the a secret with the appropriate name and key name are present


### PR DESCRIPTION
Two new functions ensureDockerRegistrySecret and ensureGithubSSHSecret added to check for secrets related to private registry and digest pinning respectively.
resource.go simply logs if the secrets are not present because they are optional

Fixes #6 
Fixes #7 