### PR TITLE
SET owner reference for tekton pipelines and tasks

### DIFF
--- a/controllers/operatorpipeline_controller.go
+++ b/controllers/operatorpipeline_controller.go
@@ -22,6 +22,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 	operatorsv1a1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	certv1alpha1 "github.com/redhat-openshift-ecosystem/operator-certification-operator/api/v1alpha1"
+	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -64,7 +65,7 @@ func (r *OperatorPipelineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	err = r.reconcileResources(pipeline.ObjectMeta)
+	err = r.reconcileResources(pipeline)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -79,5 +80,7 @@ func (r *OperatorPipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}).
 		Owns(&imagev1.ImageStream{}).
 		Owns(&operatorsv1a1.Subscription{}).
+		Owns(&tekton.Pipeline{}).
+		Owns(&tekton.Task{}).
 		Complete(r)
 }

--- a/controllers/resource.go
+++ b/controllers/resource.go
@@ -19,8 +19,8 @@ package controllers
 import (
 	"context"
 
+	certv1alpha1 "github.com/redhat-openshift-ecosystem/operator-certification-operator/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -38,33 +38,33 @@ func IsObjectFound(client client.Client, key types.NamespacedName, obj client.Ob
 }
 
 // reconcileResources will ensure that all required resources are present and up to date.
-func (r *OperatorPipelineReconciler) reconcileResources(meta metav1.ObjectMeta) error {
+func (r *OperatorPipelineReconciler) reconcileResources(pipeline *certv1alpha1.OperatorPipeline) error {
 
-	if err := r.reconcilePipelineOperator(meta); err != nil {
+	if err := r.reconcilePipelineOperator(pipeline.ObjectMeta); err != nil {
 		return err
 	}
 
-	if err := r.reconcilePipelineDependencies(meta); err != nil {
+	if err := r.reconcilePipelineDependencies(pipeline); err != nil {
 		return err
 	}
 
-	if err := r.ensureKubeConfigSecret(meta); err != nil {
+	if err := r.ensureKubeConfigSecret(pipeline.ObjectMeta); err != nil {
 		return err
 	}
 
-	if err := r.ensureGitHubAPISecret(meta); err != nil {
+	if err := r.ensureGitHubAPISecret(pipeline.ObjectMeta); err != nil {
 		return err
 	}
 
-	if err := r.ensurePyxisAPISecret(meta); err != nil {
+	if err := r.ensurePyxisAPISecret(pipeline.ObjectMeta); err != nil {
 		return err
 	}
 
-	if err := r.reconcileCertifiedImageStream(meta); err != nil {
+	if err := r.reconcileCertifiedImageStream(pipeline.ObjectMeta); err != nil {
 		return err
 	}
 
-	if err := r.reconcileMarketplaceImageStream(meta); err != nil {
+	if err := r.reconcileMarketplaceImageStream(pipeline.ObjectMeta); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This commit includes the following changes:

- Adds a pointer field on the main reconciler struct to the operator pipeline CR
- Update OperatorPipeline field on main reconciler before reconciling resources
- Uses OperatorPipeline on dependencies.go to create the owner reference and set
it for pipelines and tasks.

Those changes enable background deletion when the CR is deleted by the user.

closes #40 

Observations:

It's still not clear if the subscription should be deleted with the CR deletion since it installs the tekton operator once but may have multiple CRs depending on it. I'm not sure on that point. Glad to hear other thoughts on this.

Also although secrets are used by the CR they are not created or managed by the CR. Which means that it's not owned by the CR. I guess they shouldn't be deleted when deleting the CR. Also would like to hear the team's thoughts on this.
