### PR TITLE
Rename publicly-exposed constants to keep them private

### DIFF
--- a/controllers/image.go
+++ b/controllers/image.go
@@ -26,15 +26,15 @@ import (
 )
 
 const (
-	CERTIFIED_INDEX   = "certified-operator-index"
-	MARKETPLACE_INDEX = "redhat-marketplace-index"
+	certifiedIndex   = "certified-operator-index"
+	marketplaceIndex = "redhat-marketplace-index"
 )
 
 // reconcileCertifiedImageStream will ensure that the certified operator ImageStream is present and up to date.
 func (r *OperatorPipelineReconciler) reconcileCertifiedImageStream(meta metav1.ObjectMeta) error {
 	key := types.NamespacedName{
 		Namespace: meta.Namespace,
-		Name:      CERTIFIED_INDEX,
+		Name:      certifiedIndex,
 	}
 
 	stream := newImageStream(key)
@@ -66,7 +66,7 @@ func (r *OperatorPipelineReconciler) reconcileCertifiedImageStream(meta metav1.O
 func (r *OperatorPipelineReconciler) reconcileMarketplaceImageStream(meta metav1.ObjectMeta) error {
 	key := types.NamespacedName{
 		Namespace: meta.Namespace,
-		Name:      MARKETPLACE_INDEX,
+		Name:      marketplaceIndex,
 	}
 
 	stream := newImageStream(key)

--- a/controllers/pipeline.go
+++ b/controllers/pipeline.go
@@ -26,13 +26,13 @@ import (
 )
 
 const (
-	OS_OPERATORS_NAMESPACE               = "openshift-operators"
-	PIPELINES_OPERATOR_CHANNEL           = "stable"
-	PIPELINES_OPERATOR_CATALOG_SOURCE    = "redhat-operators"
-	PIPELINES_OPERATOR_CATALOG_SOURCE_NS = "openshift-marketplace"
-	PIPELINES_OPERATOR_NAME              = "redhat-openshift-pipelines"
-	PIPELINES_OPERATOR_VERSION           = "v1.5.2"
-	PIPELINES_OPERATOR_SUBSCRIPTION      = "openshift-pipelines-operator-rh"
+	operatorNamespace                      = "openshift-operators"
+	pipelineOperatorChannel                = "stable"
+	pipelineOperatorCatalogSource          = "redhat-operators"
+	pipelineOperatorCatalogSourceNamespace = "openshift-marketplace"
+	pipelineOperatorName                   = "redhat-openshift-pipelines"
+	pipelineOperatorVersion                = "v1.5.2"
+	pipelineOperatorSubscription           = "openshift-pipelines-operator-rh"
 )
 
 // reconcilePipelineOperator will ensure that the resources are present to provision the OpenShift Pipeline Operator
@@ -40,8 +40,8 @@ func (r *OperatorPipelineReconciler) reconcilePipelineOperator(meta metav1.Objec
 	log.Info("reconciling pipeline operator")
 
 	key := types.NamespacedName{
-		Namespace: OS_OPERATORS_NAMESPACE,
-		Name:      PIPELINES_OPERATOR_SUBSCRIPTION,
+		Namespace: operatorNamespace,
+		Name:      pipelineOperatorSubscription,
 	}
 
 	sub := newSubscription(key)
@@ -51,12 +51,12 @@ func (r *OperatorPipelineReconciler) reconcilePipelineOperator(meta metav1.Objec
 	}
 
 	sub.Spec = &operatorsv1a1.SubscriptionSpec{
-		Channel:                PIPELINES_OPERATOR_CHANNEL,
+		Channel:                pipelineOperatorChannel,
 		InstallPlanApproval:    operatorsv1a1.ApprovalAutomatic, // Use ApprovalManual instead?
-		Package:                PIPELINES_OPERATOR_SUBSCRIPTION,
-		CatalogSource:          PIPELINES_OPERATOR_CATALOG_SOURCE,
-		CatalogSourceNamespace: PIPELINES_OPERATOR_CATALOG_SOURCE_NS,
-		StartingCSV:            fmt.Sprintf("%s.%s", PIPELINES_OPERATOR_NAME, PIPELINES_OPERATOR_VERSION),
+		Package:                pipelineOperatorSubscription,
+		CatalogSource:          pipelineOperatorCatalogSource,
+		CatalogSourceNamespace: pipelineOperatorCatalogSourceNamespace,
+		StartingCSV:            fmt.Sprintf("%s.%s", pipelineOperatorName, pipelineOperatorVersion),
 	}
 
 	log.Info("creating new subscription")


### PR DESCRIPTION
Rename publicly exposed constants to ensure they are not accessible externally

* Fixes #47