### PR TITLE
Fix some linter issues

### DIFF
--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -94,7 +94,7 @@ func (r *OperatorPipelineReconciler) ensureSecret(secretName string, secretKeyNa
 	}
 	log.Info(fmt.Sprintf("successfully fetched secret %s/%s", meta.Namespace, secretName))
 	if value, ok := secret.Data[secretKeyName]; ok {
-		if value == nil || len(value) == 0 {
+		if len(value) == 0 {
 			log.Error(ErrInvalidSecret, fmt.Sprintf("the %s secret does not contain a valid value at key %s", secretName, secretKeyName))
 			return ErrInvalidSecret
 		}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
@@ -37,7 +36,6 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 


### PR DESCRIPTION
1. len() of a nil slice is zero. No need to explictly check for nil.
2. cfg was unused in the test suite.

Signed-off-by: Brad P. Crochet <brad@redhat.com>