### PR TITLE
switching to use own namespace and make namespace oco

### DIFF
--- a/bundle/manifests/operator-certification-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator-certification-operator.clusterserviceversion.yaml
@@ -20,6 +20,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    operatorframework.io/suggested-namespace: oco
     operators.operatorframework.io/builder: operator-sdk-v1.14.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: operator-certification-operator.v0.0.0-alpha
@@ -232,13 +233,13 @@ spec:
         serviceAccountName: certification-operator-controller-manager
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - certification

--- a/config/manifests/bases/operator-certification-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/operator-certification-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operatorframework.io/suggested-namespace: oco
   name: operator-certification-operator.v0.0.0
   namespace: placeholder
 spec:
@@ -25,13 +26,13 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - certification


### PR DESCRIPTION
This changes makes the operator be installed in its own namespace via the embedded OperatorHub. This gives the operator a more cleaner instillation documentation.

Signed-off-by: Adam D. Cornett <adc@redhat.com>