### PR TITLE
Fix Red Hat branding

### DIFF
--- a/bundle/manifests/operator-certification-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator-certification-operator.clusterserviceversion.yaml
@@ -234,6 +234,6 @@ spec:
     name: jomkz
   maturity: alpha
   provider:
-    name: Redhat
+    name: Red Hat
     url: https://redhat.com
   version: 0.0.0-alpha

--- a/config/manifests/bases/operator-certification-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/operator-certification-operator.clusterserviceversion.yaml
@@ -44,7 +44,7 @@ spec:
     name: jomkz
   maturity: alpha
   provider:
-    name: Redhat
+    name: Red Hat
     url: https://redhat.com
   version: 0.0.0
   minKubeVersion: 1.21.0


### PR DESCRIPTION
The name should be Red Hat, not Redhat.

Signed-off-by: Brad P. Crochet <brad@redhat.com>