### PR TITLE
Pass context to any methods called from Reconcile

### DIFF
--- a/controllers/image.go
+++ b/controllers/image.go
@@ -31,14 +31,14 @@ const (
 )
 
 // reconcileCertifiedImageStream will ensure that the certified operator ImageStream is present and up to date.
-func (r *OperatorPipelineReconciler) reconcileCertifiedImageStream(meta metav1.ObjectMeta) error {
+func (r *OperatorPipelineReconciler) reconcileCertifiedImageStream(ctx context.Context, meta metav1.ObjectMeta) error {
 	key := types.NamespacedName{
 		Namespace: meta.Namespace,
 		Name:      certifiedIndex,
 	}
 
 	stream := newImageStream(key)
-	if IsObjectFound(r.Client, key, stream) {
+	if IsObjectFound(ctx, r.Client, key, stream) {
 		log.Info("existing certified image stream found")
 		return nil // Existing ImageStream found, do nothing...
 	}
@@ -59,18 +59,18 @@ func (r *OperatorPipelineReconciler) reconcileCertifiedImageStream(meta metav1.O
 	}
 
 	log.Info("creating new certified image stream import")
-	return r.Client.Create(context.TODO(), imgimport)
+	return r.Client.Create(ctx, imgimport)
 }
 
 // reconcileMarketplaceImageStream will ensure that the Red Hat Marketplace ImageStream is present and up to date.
-func (r *OperatorPipelineReconciler) reconcileMarketplaceImageStream(meta metav1.ObjectMeta) error {
+func (r *OperatorPipelineReconciler) reconcileMarketplaceImageStream(ctx context.Context, meta metav1.ObjectMeta) error {
 	key := types.NamespacedName{
 		Namespace: meta.Namespace,
 		Name:      marketplaceIndex,
 	}
 
 	stream := newImageStream(key)
-	if IsObjectFound(r.Client, key, stream) {
+	if IsObjectFound(ctx, r.Client, key, stream) {
 		log.Info("existing marketplace image stream found")
 		return nil // Existing ImageStream found, do nothing...
 	}
@@ -91,7 +91,7 @@ func (r *OperatorPipelineReconciler) reconcileMarketplaceImageStream(meta metav1
 	}
 
 	log.Info("creating new marketplace image stream import")
-	return r.Client.Create(context.TODO(), imgimport)
+	return r.Client.Create(ctx, imgimport)
 }
 
 // newImageStream will create and return a new ImageStream instance using the given Name/Namespace.

--- a/controllers/operatorpipeline_controller.go
+++ b/controllers/operatorpipeline_controller.go
@@ -65,7 +65,7 @@ func (r *OperatorPipelineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	err = r.reconcileResources(pipeline)
+	err = r.reconcileResources(ctx, pipeline)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/pipeline.go
+++ b/controllers/pipeline.go
@@ -36,7 +36,7 @@ const (
 )
 
 // reconcilePipelineOperator will ensure that the resources are present to provision the OpenShift Pipeline Operator
-func (r *OperatorPipelineReconciler) reconcilePipelineOperator(meta metav1.ObjectMeta) error {
+func (r *OperatorPipelineReconciler) reconcilePipelineOperator(ctx context.Context, meta metav1.ObjectMeta) error {
 	log.Info("reconciling pipeline operator")
 
 	key := types.NamespacedName{
@@ -45,7 +45,7 @@ func (r *OperatorPipelineReconciler) reconcilePipelineOperator(meta metav1.Objec
 	}
 
 	sub := newSubscription(key)
-	if IsObjectFound(r.Client, key, sub) {
+	if IsObjectFound(ctx, r.Client, key, sub) {
 		log.Info("existing subscription found")
 		return nil // Existing Subscription found, do nothing...
 	}
@@ -60,7 +60,7 @@ func (r *OperatorPipelineReconciler) reconcilePipelineOperator(meta metav1.Objec
 	}
 
 	log.Info("creating new subscription")
-	return r.Client.Create(context.TODO(), sub)
+	return r.Client.Create(ctx, sub)
 }
 
 // newSubscription will create and return a new Subscription instance using the given Name/Namespace.

--- a/controllers/resource.go
+++ b/controllers/resource.go
@@ -27,44 +27,44 @@ import (
 
 // FetchObject will retrieve the object with the given namespace and name using the Kubernetes API.
 // The result will be stored in the given object.
-func FetchObject(client client.Client, key types.NamespacedName, obj client.Object) error {
-	return client.Get(context.TODO(), key, obj)
+func FetchObject(ctx context.Context, client client.Client, key types.NamespacedName, obj client.Object) error {
+	return client.Get(ctx, key, obj)
 }
 
 // IsObjectFound will perform a basic check that the given object exists via the Kubernetes API.
 // If an error occurs as part of the check, the function will return false.
-func IsObjectFound(client client.Client, key types.NamespacedName, obj client.Object) bool {
-	return !apierrors.IsNotFound(FetchObject(client, key, obj))
+func IsObjectFound(ctx context.Context, client client.Client, key types.NamespacedName, obj client.Object) bool {
+	return !apierrors.IsNotFound(FetchObject(ctx, client, key, obj))
 }
 
 // reconcileResources will ensure that all required resources are present and up to date.
-func (r *OperatorPipelineReconciler) reconcileResources(pipeline *certv1alpha1.OperatorPipeline) error {
+func (r *OperatorPipelineReconciler) reconcileResources(ctx context.Context, pipeline *certv1alpha1.OperatorPipeline) error {
 
-	if err := r.reconcilePipelineOperator(pipeline.ObjectMeta); err != nil {
+	if err := r.reconcilePipelineOperator(ctx, pipeline.ObjectMeta); err != nil {
 		return err
 	}
 
-	if err := r.reconcilePipelineDependencies(pipeline); err != nil {
+	if err := r.reconcilePipelineDependencies(ctx, pipeline); err != nil {
 		return err
 	}
 
-	if err := r.ensureKubeConfigSecret(pipeline.ObjectMeta); err != nil {
+	if err := r.ensureKubeConfigSecret(ctx, pipeline.ObjectMeta); err != nil {
 		return err
 	}
 
-	if err := r.ensureGitHubAPISecret(pipeline.ObjectMeta); err != nil {
+	if err := r.ensureGitHubAPISecret(ctx, pipeline.ObjectMeta); err != nil {
 		return err
 	}
 
-	if err := r.ensurePyxisAPISecret(pipeline.ObjectMeta); err != nil {
+	if err := r.ensurePyxisAPISecret(ctx, pipeline.ObjectMeta); err != nil {
 		return err
 	}
 
-	if err := r.reconcileCertifiedImageStream(pipeline.ObjectMeta); err != nil {
+	if err := r.reconcileCertifiedImageStream(ctx, pipeline.ObjectMeta); err != nil {
 		return err
 	}
 
-	if err := r.reconcileMarketplaceImageStream(pipeline.ObjectMeta); err != nil {
+	if err := r.reconcileMarketplaceImageStream(ctx, pipeline.ObjectMeta); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Reconcile is passed a context. That context should then be utilized in
downstream calls, rather than creating a new context via context.Background
or context.TODO.

Fixes #37

Signed-off-by: Brad P. Crochet <brad@redhat.com>