### PR TITLE
changing kubeconfigSecretName to camelcase, so it passes the CRD validation

### DIFF
--- a/config/samples/certification_v1alpha1_operatorpipeline.yaml
+++ b/config/samples/certification_v1alpha1_operatorpipeline.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   openShiftPipelineVersion: v1.5.0
   operatorPipelinesRelease: main
-  KubeconfigSecretName: "kubeconfig"
+  kubeconfigSecretName: "kubeconfig"
   gitHubSecretName: "github-api-token"
   pyxisSecretName: "pyxis-api-secret"


### PR DESCRIPTION
- Making it so that the sample file in the operator can be applied directly to a cluster without any changes, since our CRD validates these fields and expects camelCase.

Signed-off-by: Adam D. Cornett <adc@redhat.com>