### PR TITLE
Remove the 'v' from the catalog version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ endif
 BUNDLE_IMGS ?= $(BUNDLE_IMG)
 
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)
+CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(VERSION)
 
 # Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
 ifneq ($(origin CATALOG_BASE_IMG), undefined)


### PR DESCRIPTION
The tag part of the catalog-push have a extra 'v'. Remove it.

Signed-off-by: Brad P. Crochet <brad@redhat.com>