### PR TITLE
Automatically pull down operator-sdk locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,11 +153,11 @@ rm -rf $$TMP_DIR ;\
 endef
 
 .PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
-	operator-sdk generate kustomize manifests -q
+bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
+	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(RELEASE_TAG) $(BUNDLE_METADATA_OPTS)
-	operator-sdk bundle validate ./bundle
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(RELEASE_TAG) $(BUNDLE_METADATA_OPTS)
+	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
@@ -183,6 +183,18 @@ else
 OPM = $(shell which opm)
 endif
 endif
+
+.PHONY: operator-sdk
+OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
+operator-sdk: ## Download operator-sdk locally if necessary.
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(OPERATOR_SDK)) ;\
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.15.0/operator-sdk_$${OS}_$${ARCH} ;\
+	chmod +x $(OPERATOR_SDK) ;\
+	}
+
 
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
 # These images MUST exist in a registry and be pull-able.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=operator-certification-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.14.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.14.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/operator-certification-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator-certification-operator.clusterserviceversion.yaml
@@ -23,11 +23,11 @@ metadata:
     operatorframework.io/suggested-namespace: oco
     operators.operatorframework.io.bundle.channel.default.v1: alpha
     operators.operatorframework.io.bundle.channels: alpha
-    operators.operatorframework.io/builder: operator-sdk-v1.14.0
+    operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/redhat-openshift-ecosystem/operator-certification-operator
     support: Red Hat
-  name: operator-certification-operator.v0.0.0-alpha
+  name: operator-certification-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -285,4 +285,4 @@ spec:
   minKubeVersion: 1.21.0
   provider:
     name: Red Hat
-  version: 0.0.0-alpha
+  version: 0.0.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: operator-certification-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.bundle.channel.default.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.14.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.14.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 


### PR DESCRIPTION
In order to have consistent 'make bundle' runs regardless of platform, this will pull down operator-sdk and use it from ./bin.

Fixes #80

Signed-off-by: Brad P. Crochet <brad@redhat.com>
