### PR TITLE
implementing updateStatusCondition method in image streams

### DIFF
--- a/controllers/resource.go
+++ b/controllers/resource.go
@@ -72,11 +72,11 @@ func (r *OperatorPipelineReconciler) reconcileResources(ctx context.Context, pip
 		log.Info("Github SSH Secret not present or correct. Create it to enable digest pinning.")
 	}
 
-	if err := r.reconcileCertifiedImageStream(ctx, pipeline.ObjectMeta); err != nil {
+	if err := r.reconcileCertifiedImageStream(ctx, pipeline); err != nil {
 		return err
 	}
 
-	if err := r.reconcileMarketplaceImageStream(ctx, pipeline.ObjectMeta); err != nil {
+	if err := r.reconcileMarketplaceImageStream(ctx, pipeline); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- Relates: #22 
- implementing updateStatusCondition method in reconcileCertifiedImageStream and reconcileMarketplaceImageStream
- refactored method signatures to take in a `pipeline` struct so updating/setting `condition` on CR is possible

Signed-off-by: Adam D. Cornett <adc@redhat.com>