### PR TITLE
reducing the size of the builder image via go-build time module download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,21 @@ FROM docker.io/library/golang:1.17 as builder
 
 ARG release_tag
 
-# Copy the go source
-COPY . /workspace
-
 WORKDIR /workspace
 
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Copy the code
+COPY main.go main.go
+COPY Makefile Makefile
+COPY hack/ hack/
+COPY api/ api/
+COPY controllers/ controllers/
+
+# Copy git repo for sha info
+COPY .git .git
 
 # Build
 RUN make build RELEASE_TAG=${release_tag}

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager -ldflags "-X github.com/redhat-openshift-ecosystem/operator-certification-operator/version.commit=$(SHAVERSION) -X github.com/redhat-openshift-ecosystem/operator-certification-operator/version.version=$(RELEASE_TAG)" main.go
+	go build -a -o bin/manager -ldflags "-X github.com/redhat-openshift-ecosystem/operator-certification-operator/version.commit=$(SHAVERSION) -X github.com/redhat-openshift-ecosystem/operator-certification-operator/version.version=$(RELEASE_TAG)" main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go


### PR DESCRIPTION
Fixes: #86 

Since we are running `generate fmt vet` followed by `go build` - if we remove `go mod download` and instead run the build itself with `-a`,  we should be able to reduce the size of the builder image from ~3.5GB to ~2.1GB.
another optimization is to copy only the code that we need for compilation as recommended by Operator SDK,  instead of the entire codebase.

Signed-off-by: Igor Troyanovsky <itroyano@redhat.com>