### PR TITLE
add in updateStatusCondition when image streams are already found in the cluster

### DIFF
--- a/controllers/image.go
+++ b/controllers/image.go
@@ -48,6 +48,10 @@ func (r *OperatorPipelineReconciler) reconcileCertifiedImageStream(ctx context.C
 	stream := newImageStream(key)
 	if IsObjectFound(ctx, r.Client, key, stream) {
 		log.Info("existing certified image stream found")
+		if err := r.updateStatusCondition(ctx, pipeline, certifiedImageStreamAvailable, metav1.ConditionTrue, reconcileSucceeded,
+			""); err != nil {
+			return err
+		}
 		return nil // Existing ImageStream found, do nothing...
 	}
 
@@ -98,6 +102,10 @@ func (r *OperatorPipelineReconciler) reconcileMarketplaceImageStream(ctx context
 	stream := newImageStream(key)
 	if IsObjectFound(ctx, r.Client, key, stream) {
 		log.Info("existing marketplace image stream found")
+		if err := r.updateStatusCondition(ctx, pipeline, marketplaceImageStreamAvailable, metav1.ConditionTrue, reconcileSucceeded,
+			""); err != nil {
+			return err
+		}
 		return nil // Existing ImageStream found, do nothing...
 	}
 


### PR DESCRIPTION
- Fixes: #96
- add in updateStatusCondition when image streams are already found in

Signed-off-by: Adam D. Cornett <adc@redhat.com>