### PR TITLE
updating the readme, installation doc, and csv to have more consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # operator-certification-operator
-A Kubernetes operator to provision resources for the operator certification pipeline.
+A Kubernetes operator to provision resources for the operator certification pipeline. This operator is installed in all
+namespaces which can support multi-tenant scenarios. 
+
 # Requirements
 The certification operator requires that you have the following tools installed, functional, and in your path.
 - [Install](https://docs.openshift.com/container-platform/4.8/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli) oc, the OpenShift CLI tool (tested with version 4.7.13)
@@ -8,22 +10,23 @@ The certification operator requires that you have the following tools installed,
 - The certification pipeline expects you to have the source files of your Operator bundle
 
 # Pre - Installation
-### Install Openshift pipelines operator
-* Log into your cluster's OpenShift Console with cluster admin privileges
-* Use the left hand menu to navigate to *Operators*
-* In the *Operators* submenu click on *OperatorHub*
-* Use the Filter/Search box to filter on *OpenShift Pipelines*
-* Click the *Red Hat OpenShift Pipelines* tile
-* In the flyout menu to the right click the *Install* button near the top
-* On the next screen "Install Operator" scroll to the bottom of the page and click *Install*
+The below steps exist for simplicity and to make the installation clearer.
+The operator watches all namespaces, so if secrets/configs/etc already exist in another namespace, feel free to use the existing
+namespace when following the operator installation steps.
 
-### Add a new namespace where the following secrets need to be applied
+### Create a new namespace where the following secrets will be applied.
 `oc new-project oco`
 
 ### Add the kubeconfig secret which will be used to deploy the operator under test and run the certification checks.
+* Open a terminal window
+* Set the `KUBECONFIG` environment variable
 ```
-  oc create secret generic kubeconfig --from-file=kubeconfig=$KUBECONFIG
-  ```
+export KUBECONFIG=/path/to/your/cluster/kubeconfig
+```
+> *This kubeconfig will be used to deploy the Operator under test and run the certification checks.*
+```
+oc create secret generic kubeconfig --from-file=kubeconfig=$KUBECONFIG
+```
 ### Configuring steps for submitting the results
 - Add the github API token to the repo where the PR will be created
 ```
@@ -35,233 +38,27 @@ oc create secret generic github-api-token --from-literal GITHUB_TOKEN=<github to
 ```
 oc create secret generic pyxis-api-secret --from-literal pyxis_api_key=< API KEY >
 ```
+
+- Optional pipeline configurations can be found [here](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/ci-pipeline.md#optional-configuration)
+
 # Installation Steps
-Since this operator isn't in OperatorHub, the process to get it into a cluster is manaul at this point. 
+Since this operator isn't in OperatorHub, the process to get it into a cluster is manual at this point.
 Please follow the below steps to get the operator into your cluster. Follow the steps from [here](docs/INSTALLATION.md)
 
-# <a id="execute-pipeline"></a>Execute the Pipeline (Development Iterations)
-There are multiple ways to execute the Pipeline.  Below are several examples but parameters and workspaces can be removed or added per your requirements.
 
-## Clone the pipelines repository locally so you have the necessary input files to pass to tkn commands.
+# Execute the Pipeline (Development Iterations)
+A pre-requisite to running a pipeline is that a `workspace-template.yaml` exists in the directory you want to execute the `tkn` commands from.
 
-* `git clone https://github.com/redhat-openshift-ecosystem/operator-pipelines`
-* `cd operator-pipelines`
-
-## <a id="minimal-pipeline-run"></a>Minimal Pipeline Run
-
-```bash
-GIT_REPO_URL=<Git URL to your certified-operators fork >
-BUNDLE_PATH=<path to the bundle in the Git Repo> (ie: operators/my-operator/1.2.8)
+To create a workspace-template.yaml
+```
+cat <<EOF > workspace-template.yaml
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+EOF
 ```
 
-```bash
-tkn pipeline start operator-ci-pipeline \
-  --param git_repo_url=$GIT_REPO_URL \
-  --param git_branch=main \
-  --param bundle_path=$BUNDLE_PATH \
-  --param env=prod \
-  --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
-  --workspace name=kubeconfig,secret=kubeconfig \
-  --showlog
-```
-After running this command you will be prompted for several additional parameters. Accept all the defaults. 
-
-> #### Troubleshooting Tip
->
-> If you see a Permission Denied error try the GITHUB `HTTPS URL` instead of the `SSH URL`. 
-
-## <a id="img-digest-pipeline-run"></a>Pipeline Run with Image Digest Pinning
-* Execute the [Configuration Steps for Digest Pinning](#digest-pinning-config)
-
-```bash
-GIT_REPO_URL=<Git URL to your certified-operators fork >
-BUNDLE_PATH=<path to the bundle in the Git Repo> (ie: operators/my-operator/1.2.8)
-GIT_USERNAME=<your github username>
-GIT_EMAIL=<your github email address>
-```
-
-```bash
-tkn pipeline start operator-ci-pipeline \
-  --param git_repo_url=$GIT_REPO_URL \
-  --param git_branch=main \
-  --param bundle_path=$BUNDLE_PATH \
-  --param env=prod \
-  --param pin_digests=true \
-  --param git_username=$GIT_USERNAME \
-  --param git_email=$GIT_EMAIL \
-  --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
-  --workspace name=kubeconfig,secret=kubeconfig \
-  --workspace name=ssh-dir,secret=github-ssh-credentials \
-  --showlog
-```
-> #### Troubleshooting Tip
->
-> ##### Error: could not read Username for `https://github.com` 
-> try using the SSH GitHub URL in `--param git_repo_url`
-
-## <a id="private-registry-pipeline-run"></a>Pipeline Run with a Private Container Registry
-* Execute the [Configuration Steps for Private Registries](#private-registry)
-```bash
-GIT_REPO_URL=<Git URL to your certified-operators fork >
-BUNDLE_PATH=<path to the bundle in the Git Repo> (ie: operators/my-operator/1.2.8)
-GIT_USERNAME=<your github username>
-GIT_EMAIL=<your github email address>
-REGISTRY=<your image registry.  ie: quay.io>
-IMAGE_NAMESPACE=<namespace in the container registry>
-```
-
-```bash
-tkn pipeline start operator-ci-pipeline \
-  --param git_repo_url=$GIT_REPO_URL \
-  --param git_branch=main \
-  --param bundle_path=$BUNDLE_PATH \
-  --param env=prod \
-  --param pin_digests=true \
-  --param git_username=$GIT_USERNAME \
-  --param git_email=$GIT_EMAIL \
-  --param registry=$REGISTRY \
-  --param image_namespace=$IMAGE_NAMESPACE \
-  --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
-  --workspace name=kubeconfig,secret=kubeconfig \
-  --workspace name=ssh-dir,secret=github-ssh-credentials \
-  --workspace name=registry-credentials,secret=registry-dockerconfig-secret \
-  --showlog \
-
-```
-
-# <a id="submit-result"></a>Submit Results to Red Hat
-* Execute the [Configuration Steps for Submitting Results](#step7)
-
-In order to submit results add the following `--param`'s and `--workspace` where `$UPSTREAM_REPO_NAME` is equal to the repo where the Pull Request will be submitted. Typically this is a Red Hat Certification repo but you can use a repo of your own for testing.
-```bash
---param upstream_repo_name=$UPSTREAM_REPO_NAME #Repo where Pull Request (PR) will be opened
-```
-
-```bash
---param submit=true
-```
-
-```bash
---workspace name=pyxis-api-key,secret=pyxis-api-secret
-```
-
-## <a id="submit-result-minimal"></a>Submit results from Minimal Pipeline Run
-```bash
-GIT_REPO_URL=<Git URL to your certified-operators fork >
-BUNDLE_PATH=<path to the bundle in the Git Repo> (ie: operators/my-operator/1.2.8)
-```
-
-```bash
-tkn pipeline start operator-ci-pipeline \
-  --param git_repo_url=$GIT_REPO_URL \
-  --param git_branch=main \
-  --param bundle_path=$BUNDLE_PATH \
-  --param upstream_repo_name=redhat-openshift-ecosystem/certified-operators \
-  --param submit=true \
-  --param env=prod \
-  --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
-  --workspace name=kubeconfig,secret=kubeconfig \
-  --workspace name=pyxis-api-key,secret=pyxis-api-secret \
-  --showlog
-```
-
-## <a id="submit-result-img-digest"></a>Submit results with Image Digest Pinning
-* Execute the [Configuration Steps for Submitting Results](#step7)
-* Execute the [Configuration Steps for Digest Pinning](#digest-pinning-config)
-
-```bash
-GIT_REPO_URL=<Git URL to your certified-operators fork >
-BUNDLE_PATH=<path to the bundle in the Git Repo> (ie: operators/my-operator/1.2.8)
-GIT_USERNAME=<your github username>
-GIT_EMAIL=<your github email address>
-```
-
-```bash
-tkn pipeline start operator-ci-pipeline \
-  --param git_repo_url=$GIT_REPO_URL \
-  --param git_branch=main \
-  --param bundle_path=$BUNDLE_PATH \
-  --param env=prod \
-  --param pin_digests=true \
-  --param git_username=$GIT_USERNAME \
-  --param git_email=$GIT_EMAIL \
-  --param upstream_repo_name=redhat-openshift-ecosystem/certified-operators \
-  --param submit=true \
-  --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
-  --workspace name=kubeconfig,secret=kubeconfig \
-  --workspace name=ssh-dir,secret=github-ssh-credentials \
-  --workspace name=pyxis-api-key,secret=pyxis-api-secret \
-  --showlog
-```
-> #### Troubleshooting Tip
->
-> ##### Error: could not read Username for `https://github.com` 
-> try using the SSH GitHub URL in `--param git_repo_url`
-
-## <a id="submit-result-private-registy"></a>Submit results with a private container registry
-* Execute the [Configuration Steps for Submitting Results](#step7)
-* Execute the [Configuration Steps for Private Registries](#private-registry)
-```bash
-GIT_REPO_URL=<Git URL to your certified-operators fork >
-BUNDLE_PATH=<path to the bundle in the Git Repo> (ie: operators/my-operator/1.2.8)
-GIT_USERNAME=<your github username>
-GIT_EMAIL=<your github email address>
-REGISTRY=<your image registry.  ie: quay.io>
-IMAGE_NAMESPACE=<namespace in the container registry>
-```
-
-```bash
-tkn pipeline start operator-ci-pipeline \
-  --param git_repo_url=$GIT_REPO_URL \
-  --param git_branch=main \
-  --param bundle_path=$BUNDLE_PATH \
-  --param env=prod \
-  --param pin_digests=true \
-  --param git_username=$GIT_USERNAME \
-  --param git_email=$GIT_EMAIL \
-  --param registry=$REGISTRY \
-  --param image_namespace=$IMAGE_NAMESPACE \
-  --param upstream_repo_name=redhat-openshift-ecosystem/certified-operators \
-  --param submit=true \
-  --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
-  --workspace name=kubeconfig,secret=kubeconfig \
-  --workspace name=ssh-dir,secret=github-ssh-credentials \
-  --workspace name=registry-credentials,secret=registry-dockerconfig-secret \
-  --workspace name=pyxis-api-key,secret=pyxis-api-secret \
-  --showlog
-```
-
-## <a id="submit-result-registy-and-pinning"></a>Submit results with Image Digest Pinning and a private container registry
-* Execute the [Configuration Steps for Submitting Results](#step7)
-* Execute the [Configuration Steps for Digest Pinning](#digest-pinning-config)
-* Execute the [Configuration Steps for Private Registries](#private-registry)
-
-```bash
-GIT_REPO_URL=<Git URL to your certified-operators fork >
-BUNDLE_PATH=<path to the bundle in the Git Repo> (ie: operators/my-operator/1.2.8)
-GIT_USERNAME=<your github username>
-GIT_EMAIL=<your github email address>
-REGISTRY=<your image registry.  ie: quay.io>
-IMAGE_NAMESPACE=<namespace in the container registry>
-```
-
-```bash
-tkn pipeline start operator-ci-pipeline \
-  --param git_repo_url=$GIT_REPO_URL \
-  --param git_branch=main \
-  --param bundle_path=$BUNDLE_PATH \
-  --param env=prod \
-  --param pin_digests=true \
-  --param git_username=$GIT_USERNAME \
-  --param git_email=$GIT_EMAIL \
-  --param upstream_repo_name=redhat-openshift-ecosystem/certified-operators \
-  --param registry=$REGISTRY \
-  --param image_namespace=$IMAGE_NAMESPACE \
-  --param submit=true \
-  --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
-  --workspace name=kubeconfig,secret=kubeconfig \
-  --workspace name=ssh-dir,secret=github-ssh-credentials \
-  --workspace name=registry-credentials,secret=registry-dockerconfig-secret \
-  --workspace name=pyxis-api-key,secret=pyxis-api-secret \
-  --showlog
-```
+There are multiple ways to execute the Pipeline which can be found [here](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/ci-pipeline.md#execute-the-pipeline-development-iterations)

--- a/bundle/manifests/operator-certification-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator-certification-operator.clusterserviceversion.yaml
@@ -37,25 +37,78 @@ spec:
       kind: OperatorPipeline
       name: operatorpipelines.certification.redhat.com
       version: v1alpha1
-  description: "A Kubernetes Operator to provision resources for the Operator Certification
-    Pipeline. \n# Requirements\nThe certification operator requires that you have
-    the following tools installed, functional, and in your path.\n - [Install](https://docs.openshift.com/container-platform/4.8/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli)
-    oc, the OpenShift CLI tool (tested with version 4.7.13)\n - [Install](https://tekton.dev/docs/cli/)
-    tkn, the Tekton CLI tool (tested with version 0.19.1)\n - [Install](https://git-scm.com/downloads)
-    git, the Git CLI tool (tested with 2.32.0)\n - The certification pipeline expects
-    you to have the source files of your Operator bundle\n \n# Pre - Installation\n
-    \n### Change to the namespace where the following secrets need to be applied\n
-    ```\noc project openshift-operators\n ```\n \n### Add the kubeconfig secret which
-    will be used to deploy the operator under test and run the certification checks.\n
-    ```\n oc create secret generic kubeconfig --from-file=kubeconfig=$KUBECONFIG\n
-    ```\n \n### Configuring steps for submitting the results\n - Add the github API
-    token to the repo where the PR will be created\n ```\n oc create secret generic
-    github-api-token --from-literal GITHUB_TOKEN=<github token>\n ```\n - Add RedHat
-    Container API access key\n This API access key is specifically related to your
-    unique partner account for Red Hat Connect portal. Instructions to obtain your
-    API key can be found: [here](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/operator-cert-workflow.md#step-b---get-api-key)\n
-    ```\n oc create secret generic pyxis-api-secret --from-literal pyxis_api_key=<
-    API KEY >\n ```"
+  description: |-
+    A Kubernetes operator to provision resources for the operator certification pipeline. This operator is installed in all namespaces which can support multi-tenant scenarios.
+
+
+    **Requirements**
+
+
+    The certification operator requires that you have the following tools installed, functional, and in your path.
+    - [Install](https://docs.openshift.com/container-platform/4.8/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli) oc, the OpenShift CLI tool (tested with version 4.7.13)
+    - [Install](https://tekton.dev/docs/cli/) tkn, the Tekton CLI tool (tested with version 0.19.1)
+    - [Install](https://git-scm.com/downloads) git, the Git CLI tool (tested with 2.32.0)
+    - The certification pipeline expects you to have the source files of your Operator bundle
+
+
+    **Pre - Installation**
+
+
+    The below steps exist for simplicity and to make the installation clearer. The operator watches all namespaces, so if secrets/configs/etc already exist in another namespace, feel free to use the existing namespace when following the operator installation steps.
+
+
+    **Create a new namespace where the following secrets will be applied.**
+    ```
+    oc new-project oco
+    ```
+
+
+    **Add the kubeconfig secret which will be used to deploy the operator under test and run the certification checks.**
+    * Open a terminal window
+    * Set the `KUBECONFIG` environment variable
+    ```
+    export KUBECONFIG=/path/to/your/cluster/kubeconfig
+    ```
+    > *This kubeconfig will be used to deploy the Operator under test and run the certification checks.*
+    ```
+    oc create secret generic kubeconfig --from-file=kubeconfig=$KUBECONFIG
+    ```
+
+
+    **Configuring steps for submitting the results**
+    - Add the github API token to the repo where the PR will be created
+    ```
+    oc create secret generic github-api-token --from-literal GITHUB_TOKEN=<github token>
+    ```
+    - Add RedHat Container API access key
+
+      This API access key is specifically related to your unique partner account for Red Hat Connect portal. Instructions to obtain your API key can be found: [here](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/operator-cert-workflow.md#step-b---get-api-key)
+    ```
+    oc create secret generic pyxis-api-secret --from-literal pyxis_api_key=< API KEY >
+    ```
+
+    - Optional pipeline configurations can be found [here](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/ci-pipeline.md#optional-configuration)
+
+
+
+    **Execute the Pipeline (Development Iterations)**
+
+
+    A pre-requisite to running a pipeline is that a `workspace-template.yaml` exists in the directory you want to execute the `tkn` commands from.
+
+    To create a workspace-template.yaml
+    ```
+    cat <<EOF > workspace-template.yaml
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+    EOF
+    ```
+
+    There are multiple ways to execute the Pipeline which can be found [here](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/ci-pipeline.md#execute-the-pipeline-development-iterations)
   displayName: Operator Certification Operator
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAAGUAAABlCAYAAABUfC3PAAAQrElEQVR4Xu2dd3wU1RbHfymkQBomkAYEiICCSFDkw3uACaIi0mJBKT4JRgSehSAoyEMMykMUpfgBBaSEjw8BfX4oL4ogQmjqB5CignQSSgrpZdOTeZ8zYdbdzczO3dm5uxtx/oLMnXvPOd97bj33rhuawFOTeVmoPnsC1edOoC4rHbWZ6aLU9P/6smJZDTzDo+AZ3l58531vHNz9g+DVOQa+vQa4ubrKLilg1dnjQnnaVlT9nGbV8FqNS8AIEMFqHhePZhEdXMoOLiOMYe8WoWLfVhAMpdqvFYLadwTJNzYefsMS4N2lp9Nt4lQBqFkq+XwJDKkpDgehBIoA+Y9OQuCYqU6zjVMKrji6VyhelYzKY/vUKrFT3/sNHYfAF5Id3rw5FEpTgWFZExwNxyFQqOMu/DDJ5T1DzS39R01B8PSl3G3GvYD8D6YIpZuWqunbZN67+wWKTRrPPocbFGqq8ucmoDYro8kY3BZBfe6JRXByCpf+hguUP5t3KMEir2k5bQn8h43X1Y66ZkZD3Nxp8ag+f9KWStfk09JAICR5vW621C0jaq5yp8e7zHzD0aS9OvVAxMaTuthTl0xK/7dOyJ873tF2cLnyaOLZ6oOtdq8K2A3lLyDmdYP6mdCVaXaBsQvKX0DkndWtRQCC522EX/8hmuyr6SMSxVWA0PK8z71x8IxoWKan5fzKn9NQX1rklOZNAFBSA9TDDR3f34jAQaNstrHNH7gKEFp6p+EozRfkHpqwFq1KdigcCUgd/QOAm5s2MDZDoSX23Ncec0otlAr1G5qA4LfWqcpQdeFX5E4dirrsK6pp7U1gCUTKz8PTEz2O1dpkZ5sS0xpWzsQ4pw57yUPCNxxXtaEgCCgpKYFQVYniIWGq6e1JoAREyrOZjy+6H65gtjVzQiogc3QPwdkTQxrZKDVZkhEkIHV1dQ3NyO+HUZI02B67K36rBkT6sEW7aHRJvchkb6ZElPGNaSOE8n3buCjGmimLl1gCobzdhXoUP9KKtRjmdKxApAwjE2cidMoCVZurJnCVjp3kCBidhJavLlautTebLMlDTBNWTh+Gml9/YDa4WkJbgUgdf+eU/WjRs79Vu6tCofWsrDExTu1HJAMF0ZL5hLdk7SXnIaYJa1fPQcWXy9VszfReCxApY++AIHQ7WGQfFGc3W7R0EZj4Jnz7DoFHiHyHrQaEDOLv1wJuN66h9ItlKNm4hMn4consASLlF/p4IiKT1yiCsUrMmcNf7x79EJKcAs/IjhCqK1Hx407UXD6NwPGzzGzFAkRsOjYvRouBT8Ar+i7x+/IDqShclGTTfo8eQKRmrOdJQRuUa8OiBEdvUpFnhH78PTzbRKP22kUUfPAKKg59IxqSZu+R2y8bobACsezoW770LvyemAT3FoGgwQvLvEsvIJLwAXfG4PbNJ2TBKNIq/nyxULhoqmY31/Jhq4Vb0Dx2BGpvXEPev8ag6uTBRtkEv5UC2r9gBUIZCLs3oWzhi43yooFD0Ivzxb8XLZ9l1qzRBNWrSwwKPkyC3kAkQbqsPyDb6StCuRIXKDgqKI68IzzlMNwDb0Ph0testvkUfhqxPR1ldYDcKMvS8u6VBhSPaGe1joR+9C18/jYIVcf2IXtiHKQVA5qTZY6JEdeypKUTLZVN6RuluYssFN5eIi0iUk30+ftgNGvXGbWZl5EzaQBTG+/9wJPwnrFSrMHWHvfaGpQl9mZaZmnx0NM3l24EuHk3N2b7S4wbFyDWvEUWCo++hEBQFIi4ohse1ciW1K5TyCrr4xHWDn4Lt0No3bYRHFEpDbP4215dLEZHmj7nEweg7Ggaq1g2p5PzlkZQeC7JS/2BnOQZ96lOmRQV9h35IjzadxXf16Wf1jQfUZIte8VcZH2SbLOxWT+glWTLkVgjS2S/ECvwDCeVU14cAU2PZ9VD93TWVp0NJw7h3Lh+updpmmHwwHhELd5qZGEGhWbv14d34CoAzT/CVh8wK4P298tSU7iWq5Y5DSAo8t4rNh4BcSOMyYW6Wpy4p5na53a9t1xFNoPCu4MnydsdLBcP/dQV3jCu9lJFqM1qOAjkrMdy2Bv4QDxaPvwUgh58AqU/7MTFV4ZzFS164SbjLqUZFN5L82Er0+DVrTeu9GsunqyiZXh6aG3NmY+1eUhAv0cRvfxrpL8+CoU7N3MT03QyaYTCu+ny7fsoWi/5GnmzRsHwXYNy0pE32lN31sMyMey0Jg3Nu/fGyd5/DJX1lte0CTNC4d10td1biJpzJ8XJmas8LEAkWWOOVqEg9TNcSX6em/jSDN8IhedqsLgPMnURro+gvsM1Ar5tAUIUWo1NQpvXFuHU4A6o5qSDtHpshMJzWcXVvMRWIJJr3H2wEEW7v+LmLdJEUoRCARFZY3tycUtxCPzpfpfxEq1AyDhtZn6EkKcmcxsiS5EvIhSes3iKPHFv7o/rj93OBbotmdoDxNi3HKtBxhvPcBuJ3fML3EQohSvfEoo/nWuLfsxpo36qQf6CySjbupr5Gx4J9QBCct2xuSG86czTfFqWqBmLIULRe2mFFh8pjNSn1wBxKzejtzsPOzPnqRcQKjD0uRkIf/nfuDDhQbF8vRcraclFhKLXpJFub6CVYDqrYfmUpa4HHdN29MxdLyB+veIQPjkZfr0ah8kWbF8vLlpW37yehLm2yCRseV9sA5T0XqpbE6rlWFsBlj6mTbOcpKGoltlRVC1AQwK9gLR5fQlajZ1iVYK6smJkrngbeZ8t0iDpH59QtIsuUFiAULFVVVUoNxhQ9d5EVO35r13Cq32sFxDyjrBJ8mFNpjKQbgaDASUr5qBws/ZQJhEKHYujHT+tD21aha7Yq/q5JDQlpB1BnvG9egHximiPbjv+CNRQUtJUNzehHukPaI/G1AUKHSejYAdrj6nQUjo9g+NMy9YLCOUZ9U4Kbhs+zmbdKndtQs67jQM1VGvuzQR2e0rUEes75XJAqGweQdd6AiEZu32bDi+ZrWvJuEq64cZVZDytfeWbKxRFoakJY4gyYa1ZlE5vIJRnz5PKFc6abm6VBqQPth5BY003blCsCS32KzpC4QHEGhQ13VwSiprQIpQrZ1A8oa8tziCblhcQpeaLRTe34nykx3fWrJvdnmLZ0bMILTY3ClGLtmjCE4hcR8+qW81Pu5D5xmhbVDFLazcUmsVTuCk9rELrcYiHNxDSh2bxndY0DPdZdaOJ3/XRPVGj8Zwl7UDqMnkkb/Ho84g4eWJ56r9aBsMq9QmZUl6OACKVTbP5gCcnMetmr5foNqOnvXb/TWdQ76keimNvs+VIIBKYqA1HgIiO6vXNzqEwFWCEoleYasCSHcCdvWUX0qjJql6TrCl6UbKGM4AYPWbZDnh2k9eNZvFlX36MvE+0e79UDkW16L50TzG+vv+YAffIjvBs3UY89FO67HW7YPCah6hXffMUzcLaofXL8+E/8HGUHW24lLTy1GFdYEglGVeJeV6aFnW4HtkT7pc9a8JqFGd6iKWMHRdvgU+n7jg9lM9OqnGTi2d4UeSWC6gvykPW+D6sDMzSuRIQEqzH4XLkbliKzKVvaNJH7SMKMxKbL3tXiq0VJIYXTVmIjD7qgwDLfFwNSPDjz6PdnFU4HsNnJ1WKwDeGGOmx0aUEh/bpaecxfx57IJurASHduqZeQE3ONZxP5BNQ6NMqDF2/z24InKBH7316U0DBs1eL5xRZvcUVgbTo2Q+dUw7gXEJ/GI43Poup1iyxvJeORBih8IxoIYFYvcUVgZD83fflovLCKW5eQmVIkfdGKDwD8qhAltBVVwFCO46mQRBhL8xG+D/f5hqyanoFldlRCL0mkUqu2mZHlvjq2uDwRklcBYiHfxAoPPXS1MdQvGeruMnVbccl5Kx7n9uIi4xhevbRDArP+QoVTAdQI7ZcQNXRvSheN1+8VpAeVwFCstBhIZqLUHTK+efiEP3xDlHG3wY2rkgs/QRrGtMbjsyg8G7CRKUTZyNo0juirBRyRCeCCw+noXDPVtQ56d5HU8OZ7svT0ToKIj39aDS3SHsq2/L2vEYHUXk3YbR42XZPoWwFKt67DdfeT9IlqI21hlqmu/tQETz8Ao1/rq8sx7ln+6Li7AmtWap+Z3klSCMoPGf3knSR29Nlz9JTpGHGmwmqSvBKYLp/YloGNWVnRsZwqyyW14HIHl7neVaFlJUL3suYMx4F22w7IUydcvCIBHEziv5ND9Xo0qNpYidt62MtEpJXhZEmjKayykLh2eFTp+4xOAFt3za/LTV/yxqbDuO0fiYJYZOTzZoaU8XotNWlKfHMzQ5Bveu7q3D39ROzoVVgCt4uP3sCZUfSuPV3tAAZPNb8979kofA6lCqNsuguyDu+aDhSQB7i4RckHl2ryc/BuWf6qHaqLEFyoteUFCFn2WzVMFJa02o7azlqC/Nw9Z2JKN6faquTaUqvdEueLBQqQW9vsRz2UqAbdepSM0Pzgc7/+QnNgkNR+O0mpM8cI6uoNGRVs4K0p25tz5zK7LhkK3y79EDpj7twYfIjatnq+l7OS6gARSj0Uq++RW4eQs2F3BCYDnxGTlsoKk/tuOVpXLWoRfquUZCDxTYtwYiatx5+994veufl6SO5rWcpUbR2l6RVKHqsh2mdGLZLXm2M4608/xty1i4QDShFlygpKxd1QkqmDwhGxJR3EfTQSHi3jUZNXjZy1r6H3A3a75O0x22ULmBT9RRKYM+BIq1ATJUlz2k1+iV4t6HABQFwU97LsBYGFBgQAHc3wHD8EDKXzXa4Z5jqRFu+HdbsU3QIq54idpYaj0roAcSyJnb8aDsCY4fJVlC1uKyq1BRkfzjNnsqty7csd9+rQtHS6fMAQnIoHeBRA0Lf2nuYRxcitIUhMwS2zJsJii3NGC8gJIPcyIsFSIP82qMW9QKi1mxJ5TBDYflFCJ5ASGAasdHoS1qbYgVib8C1HlBs+WUIZigkmLXLo3kDkQwjNWGsQFyh6ZK7ktAaaJugUEZyw2RHAZEU6bTtLKoDQpgqsJB+BlfG23/kgqkwmURafm3IZihUbl7yOIGiU+hxNBAqkyIVI1fshhAYbNVWdacO49pLfH43hRWS2r32cvlogiKBKU1dz+0iZRalQybPhd+g0WZwSCHhxlUUfDoPpbv5HgtXk1ELEMpTMxT6+OJTPYTiM7fWT9KqgZDeawViNxTK4OzQaMFw5SKrrLdEOnuA6ALlLzDm9cxeILpBoYwuJ8YKhUcajgfcio+WUZaSnezqUywzzVk6U8hc+574Mxq30kMTw44rd6n+1harTXSFQoUajh8QLk18GDWVFawyNOl0tvxUIKuiukORCv6zN2fUXEU8N4PpJwJZYUjpuEGhAop3bhKuvDn+T+c1chEothreWnquUKSCM6bGCwV7tjX5vob6jogp8xtFn+gJRNfRF4tg1KQVHd3f5ODQxlTI8HFWfwaQRX/WNA7xFEthmgocR8NwSJ+iVjOuJycKBd987nJ9DvUZwcMTuHTiajZxePOlJBANCHLXLoDh/G+oq61lkVv3NNRfBPQdhJBnp+k239AqpFOaL2vCEqCCLz5B+dmTqCop0qqX6nc0pPUOCUVg/yEIGpHgdBCmArscFEtrEqSyH79Dxe8/o+p6OmrLy2z2JvG+E28f+LbvguZ3/w1+9w9xKQiWOrs8FDWvqs1rOLJn+fh07eXShrem1/8BWjy0OmdfIfEAAAAASUVORK5CYII=

--- a/config/manifests/bases/operator-certification-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/operator-certification-operator.clusterserviceversion.yaml
@@ -20,25 +20,78 @@ spec:
       kind: OperatorPipeline
       name: operatorpipelines.certification.redhat.com
       version: v1alpha1
-  description: "A Kubernetes Operator to provision resources for the Operator Certification
-    Pipeline. \n# Requirements\nThe certification operator requires that you have
-    the following tools installed, functional, and in your path.\n - [Install](https://docs.openshift.com/container-platform/4.8/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli)
-    oc, the OpenShift CLI tool (tested with version 4.7.13)\n - [Install](https://tekton.dev/docs/cli/)
-    tkn, the Tekton CLI tool (tested with version 0.19.1)\n - [Install](https://git-scm.com/downloads)
-    git, the Git CLI tool (tested with 2.32.0)\n - The certification pipeline expects
-    you to have the source files of your Operator bundle\n \n# Pre - Installation\n
-    \n### Change to the namespace where the following secrets need to be applied\n
-    ```\noc project openshift-operators\n ```\n \n### Add the kubeconfig secret which
-    will be used to deploy the operator under test and run the certification checks.\n
-    ```\n oc create secret generic kubeconfig --from-file=kubeconfig=$KUBECONFIG\n
-    ```\n \n### Configuring steps for submitting the results\n - Add the github API
-    token to the repo where the PR will be created\n ```\n oc create secret generic
-    github-api-token --from-literal GITHUB_TOKEN=<github token>\n ```\n - Add RedHat
-    Container API access key\n This API access key is specifically related to your
-    unique partner account for Red Hat Connect portal. Instructions to obtain your
-    API key can be found: [here](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/operator-cert-workflow.md#step-b---get-api-key)\n
-    ```\n oc create secret generic pyxis-api-secret --from-literal pyxis_api_key=<
-    API KEY >\n ```"
+  description: |-
+    A Kubernetes operator to provision resources for the operator certification pipeline. This operator is installed in all namespaces which can support multi-tenant scenarios.
+
+
+    **Requirements**
+
+
+    The certification operator requires that you have the following tools installed, functional, and in your path.
+    - [Install](https://docs.openshift.com/container-platform/4.8/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli) oc, the OpenShift CLI tool (tested with version 4.7.13)
+    - [Install](https://tekton.dev/docs/cli/) tkn, the Tekton CLI tool (tested with version 0.19.1)
+    - [Install](https://git-scm.com/downloads) git, the Git CLI tool (tested with 2.32.0)
+    - The certification pipeline expects you to have the source files of your Operator bundle
+
+
+    **Pre - Installation**
+
+
+    The below steps exist for simplicity and to make the installation clearer. The operator watches all namespaces, so if secrets/configs/etc already exist in another namespace, feel free to use the existing namespace when following the operator installation steps.
+
+
+    **Create a new namespace where the following secrets will be applied.**
+    ```
+    oc new-project oco
+    ```
+
+
+    **Add the kubeconfig secret which will be used to deploy the operator under test and run the certification checks.**
+    * Open a terminal window
+    * Set the `KUBECONFIG` environment variable
+    ```
+    export KUBECONFIG=/path/to/your/cluster/kubeconfig
+    ```
+    > *This kubeconfig will be used to deploy the Operator under test and run the certification checks.*
+    ```
+    oc create secret generic kubeconfig --from-file=kubeconfig=$KUBECONFIG
+    ```
+
+
+    **Configuring steps for submitting the results**
+    - Add the github API token to the repo where the PR will be created
+    ```
+    oc create secret generic github-api-token --from-literal GITHUB_TOKEN=<github token>
+    ```
+    - Add RedHat Container API access key
+
+      This API access key is specifically related to your unique partner account for Red Hat Connect portal. Instructions to obtain your API key can be found: [here](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/operator-cert-workflow.md#step-b---get-api-key)
+    ```
+    oc create secret generic pyxis-api-secret --from-literal pyxis_api_key=< API KEY >
+    ```
+
+    - Optional pipeline configurations can be found [here](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/ci-pipeline.md#optional-configuration)
+
+
+
+    **Execute the Pipeline (Development Iterations)**
+
+
+    A pre-requisite to running a pipeline is that a `workspace-template.yaml` exists in the directory you want to execute the `tkn` commands from.
+
+    To create a workspace-template.yaml
+    ```
+    cat <<EOF > workspace-template.yaml
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+    EOF
+    ```
+
+    There are multiple ways to execute the Pipeline which can be found [here](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/ci-pipeline.md#execute-the-pipeline-development-iterations)
   displayName: Operator Certification Operator
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAAGUAAABlCAYAAABUfC3PAAAQrElEQVR4Xu2dd3wU1RbHfymkQBomkAYEiICCSFDkw3uACaIi0mJBKT4JRgSehSAoyEMMykMUpfgBBaSEjw8BfX4oL4ogQmjqB5CignQSSgrpZdOTeZ8zYdbdzczO3dm5uxtx/oLMnXvPOd97bj33rhuawFOTeVmoPnsC1edOoC4rHbWZ6aLU9P/6smJZDTzDo+AZ3l58531vHNz9g+DVOQa+vQa4ubrKLilg1dnjQnnaVlT9nGbV8FqNS8AIEMFqHhePZhEdXMoOLiOMYe8WoWLfVhAMpdqvFYLadwTJNzYefsMS4N2lp9Nt4lQBqFkq+XwJDKkpDgehBIoA+Y9OQuCYqU6zjVMKrji6VyhelYzKY/vUKrFT3/sNHYfAF5Id3rw5FEpTgWFZExwNxyFQqOMu/DDJ5T1DzS39R01B8PSl3G3GvYD8D6YIpZuWqunbZN67+wWKTRrPPocbFGqq8ucmoDYro8kY3BZBfe6JRXByCpf+hguUP5t3KMEir2k5bQn8h43X1Y66ZkZD3Nxp8ag+f9KWStfk09JAICR5vW621C0jaq5yp8e7zHzD0aS9OvVAxMaTuthTl0xK/7dOyJ873tF2cLnyaOLZ6oOtdq8K2A3lLyDmdYP6mdCVaXaBsQvKX0DkndWtRQCC522EX/8hmuyr6SMSxVWA0PK8z71x8IxoWKan5fzKn9NQX1rklOZNAFBSA9TDDR3f34jAQaNstrHNH7gKEFp6p+EozRfkHpqwFq1KdigcCUgd/QOAm5s2MDZDoSX23Ncec0otlAr1G5qA4LfWqcpQdeFX5E4dirrsK6pp7U1gCUTKz8PTEz2O1dpkZ5sS0xpWzsQ4pw57yUPCNxxXtaEgCCgpKYFQVYniIWGq6e1JoAREyrOZjy+6H65gtjVzQiogc3QPwdkTQxrZKDVZkhEkIHV1dQ3NyO+HUZI02B67K36rBkT6sEW7aHRJvchkb6ZElPGNaSOE8n3buCjGmimLl1gCobzdhXoUP9KKtRjmdKxApAwjE2cidMoCVZurJnCVjp3kCBidhJavLlautTebLMlDTBNWTh+Gml9/YDa4WkJbgUgdf+eU/WjRs79Vu6tCofWsrDExTu1HJAMF0ZL5hLdk7SXnIaYJa1fPQcWXy9VszfReCxApY++AIHQ7WGQfFGc3W7R0EZj4Jnz7DoFHiHyHrQaEDOLv1wJuN66h9ItlKNm4hMn4consASLlF/p4IiKT1yiCsUrMmcNf7x79EJKcAs/IjhCqK1Hx407UXD6NwPGzzGzFAkRsOjYvRouBT8Ar+i7x+/IDqShclGTTfo8eQKRmrOdJQRuUa8OiBEdvUpFnhH78PTzbRKP22kUUfPAKKg59IxqSZu+R2y8bobACsezoW770LvyemAT3FoGgwQvLvEsvIJLwAXfG4PbNJ2TBKNIq/nyxULhoqmY31/Jhq4Vb0Dx2BGpvXEPev8ag6uTBRtkEv5UC2r9gBUIZCLs3oWzhi43yooFD0Ivzxb8XLZ9l1qzRBNWrSwwKPkyC3kAkQbqsPyDb6StCuRIXKDgqKI68IzzlMNwDb0Ph0testvkUfhqxPR1ldYDcKMvS8u6VBhSPaGe1joR+9C18/jYIVcf2IXtiHKQVA5qTZY6JEdeypKUTLZVN6RuluYssFN5eIi0iUk30+ftgNGvXGbWZl5EzaQBTG+/9wJPwnrFSrMHWHvfaGpQl9mZaZmnx0NM3l24EuHk3N2b7S4wbFyDWvEUWCo++hEBQFIi4ohse1ciW1K5TyCrr4xHWDn4Lt0No3bYRHFEpDbP4215dLEZHmj7nEweg7Ggaq1g2p5PzlkZQeC7JS/2BnOQZ96lOmRQV9h35IjzadxXf16Wf1jQfUZIte8VcZH2SbLOxWT+glWTLkVgjS2S/ECvwDCeVU14cAU2PZ9VD93TWVp0NJw7h3Lh+updpmmHwwHhELd5qZGEGhWbv14d34CoAzT/CVh8wK4P298tSU7iWq5Y5DSAo8t4rNh4BcSOMyYW6Wpy4p5na53a9t1xFNoPCu4MnydsdLBcP/dQV3jCu9lJFqM1qOAjkrMdy2Bv4QDxaPvwUgh58AqU/7MTFV4ZzFS164SbjLqUZFN5L82Er0+DVrTeu9GsunqyiZXh6aG3NmY+1eUhAv0cRvfxrpL8+CoU7N3MT03QyaYTCu+ny7fsoWi/5GnmzRsHwXYNy0pE32lN31sMyMey0Jg3Nu/fGyd5/DJX1lte0CTNC4d10td1biJpzJ8XJmas8LEAkWWOOVqEg9TNcSX6em/jSDN8IhedqsLgPMnURro+gvsM1Ar5tAUIUWo1NQpvXFuHU4A6o5qSDtHpshMJzWcXVvMRWIJJr3H2wEEW7v+LmLdJEUoRCARFZY3tycUtxCPzpfpfxEq1AyDhtZn6EkKcmcxsiS5EvIhSes3iKPHFv7o/rj93OBbotmdoDxNi3HKtBxhvPcBuJ3fML3EQohSvfEoo/nWuLfsxpo36qQf6CySjbupr5Gx4J9QBCct2xuSG86czTfFqWqBmLIULRe2mFFh8pjNSn1wBxKzejtzsPOzPnqRcQKjD0uRkIf/nfuDDhQbF8vRcraclFhKLXpJFub6CVYDqrYfmUpa4HHdN29MxdLyB+veIQPjkZfr0ah8kWbF8vLlpW37yehLm2yCRseV9sA5T0XqpbE6rlWFsBlj6mTbOcpKGoltlRVC1AQwK9gLR5fQlajZ1iVYK6smJkrngbeZ8t0iDpH59QtIsuUFiAULFVVVUoNxhQ9d5EVO35r13Cq32sFxDyjrBJ8mFNpjKQbgaDASUr5qBws/ZQJhEKHYujHT+tD21aha7Yq/q5JDQlpB1BnvG9egHximiPbjv+CNRQUtJUNzehHukPaI/G1AUKHSejYAdrj6nQUjo9g+NMy9YLCOUZ9U4Kbhs+zmbdKndtQs67jQM1VGvuzQR2e0rUEes75XJAqGweQdd6AiEZu32bDi+ZrWvJuEq64cZVZDytfeWbKxRFoakJY4gyYa1ZlE5vIJRnz5PKFc6abm6VBqQPth5BY003blCsCS32KzpC4QHEGhQ13VwSiprQIpQrZ1A8oa8tziCblhcQpeaLRTe34nykx3fWrJvdnmLZ0bMILTY3ClGLtmjCE4hcR8+qW81Pu5D5xmhbVDFLazcUmsVTuCk9rELrcYiHNxDSh2bxndY0DPdZdaOJ3/XRPVGj8Zwl7UDqMnkkb/Ho84g4eWJ56r9aBsMq9QmZUl6OACKVTbP5gCcnMetmr5foNqOnvXb/TWdQ76keimNvs+VIIBKYqA1HgIiO6vXNzqEwFWCEoleYasCSHcCdvWUX0qjJql6TrCl6UbKGM4AYPWbZDnh2k9eNZvFlX36MvE+0e79UDkW16L50TzG+vv+YAffIjvBs3UY89FO67HW7YPCah6hXffMUzcLaofXL8+E/8HGUHW24lLTy1GFdYEglGVeJeV6aFnW4HtkT7pc9a8JqFGd6iKWMHRdvgU+n7jg9lM9OqnGTi2d4UeSWC6gvykPW+D6sDMzSuRIQEqzH4XLkbliKzKVvaNJH7SMKMxKbL3tXiq0VJIYXTVmIjD7qgwDLfFwNSPDjz6PdnFU4HsNnJ1WKwDeGGOmx0aUEh/bpaecxfx57IJurASHduqZeQE3ONZxP5BNQ6NMqDF2/z24InKBH7316U0DBs1eL5xRZvcUVgbTo2Q+dUw7gXEJ/GI43Poup1iyxvJeORBih8IxoIYFYvcUVgZD83fflovLCKW5eQmVIkfdGKDwD8qhAltBVVwFCO46mQRBhL8xG+D/f5hqyanoFldlRCL0mkUqu2mZHlvjq2uDwRklcBYiHfxAoPPXS1MdQvGeruMnVbccl5Kx7n9uIi4xhevbRDArP+QoVTAdQI7ZcQNXRvSheN1+8VpAeVwFCstBhIZqLUHTK+efiEP3xDlHG3wY2rkgs/QRrGtMbjsyg8G7CRKUTZyNo0juirBRyRCeCCw+noXDPVtQ56d5HU8OZ7svT0ToKIj39aDS3SHsq2/L2vEYHUXk3YbR42XZPoWwFKt67DdfeT9IlqI21hlqmu/tQETz8Ao1/rq8sx7ln+6Li7AmtWap+Z3klSCMoPGf3knSR29Nlz9JTpGHGmwmqSvBKYLp/YloGNWVnRsZwqyyW14HIHl7neVaFlJUL3suYMx4F22w7IUydcvCIBHEziv5ND9Xo0qNpYidt62MtEpJXhZEmjKayykLh2eFTp+4xOAFt3za/LTV/yxqbDuO0fiYJYZOTzZoaU8XotNWlKfHMzQ5Bveu7q3D39ROzoVVgCt4uP3sCZUfSuPV3tAAZPNb8979kofA6lCqNsuguyDu+aDhSQB7i4RckHl2ryc/BuWf6qHaqLEFyoteUFCFn2WzVMFJa02o7azlqC/Nw9Z2JKN6faquTaUqvdEueLBQqQW9vsRz2UqAbdepSM0Pzgc7/+QnNgkNR+O0mpM8cI6uoNGRVs4K0p25tz5zK7LhkK3y79EDpj7twYfIjatnq+l7OS6gARSj0Uq++RW4eQs2F3BCYDnxGTlsoKk/tuOVpXLWoRfquUZCDxTYtwYiatx5+994veufl6SO5rWcpUbR2l6RVKHqsh2mdGLZLXm2M4608/xty1i4QDShFlygpKxd1QkqmDwhGxJR3EfTQSHi3jUZNXjZy1r6H3A3a75O0x22ULmBT9RRKYM+BIq1ATJUlz2k1+iV4t6HABQFwU97LsBYGFBgQAHc3wHD8EDKXzXa4Z5jqRFu+HdbsU3QIq54idpYaj0roAcSyJnb8aDsCY4fJVlC1uKyq1BRkfzjNnsqty7csd9+rQtHS6fMAQnIoHeBRA0Lf2nuYRxcitIUhMwS2zJsJii3NGC8gJIPcyIsFSIP82qMW9QKi1mxJ5TBDYflFCJ5ASGAasdHoS1qbYgVib8C1HlBs+WUIZigkmLXLo3kDkQwjNWGsQFyh6ZK7ktAaaJugUEZyw2RHAZEU6bTtLKoDQpgqsJB+BlfG23/kgqkwmURafm3IZihUbl7yOIGiU+hxNBAqkyIVI1fshhAYbNVWdacO49pLfH43hRWS2r32cvlogiKBKU1dz+0iZRalQybPhd+g0WZwSCHhxlUUfDoPpbv5HgtXk1ELEMpTMxT6+OJTPYTiM7fWT9KqgZDeawViNxTK4OzQaMFw5SKrrLdEOnuA6ALlLzDm9cxeILpBoYwuJ8YKhUcajgfcio+WUZaSnezqUywzzVk6U8hc+574Mxq30kMTw44rd6n+1harTXSFQoUajh8QLk18GDWVFawyNOl0tvxUIKuiukORCv6zN2fUXEU8N4PpJwJZYUjpuEGhAop3bhKuvDn+T+c1chEothreWnquUKSCM6bGCwV7tjX5vob6jogp8xtFn+gJRNfRF4tg1KQVHd3f5ODQxlTI8HFWfwaQRX/WNA7xFEthmgocR8NwSJ+iVjOuJycKBd987nJ9DvUZwcMTuHTiajZxePOlJBANCHLXLoDh/G+oq61lkVv3NNRfBPQdhJBnp+k239AqpFOaL2vCEqCCLz5B+dmTqCop0qqX6nc0pPUOCUVg/yEIGpHgdBCmArscFEtrEqSyH79Dxe8/o+p6OmrLy2z2JvG+E28f+LbvguZ3/w1+9w9xKQiWOrs8FDWvqs1rOLJn+fh07eXShrem1/8BWjy0OmdfIfEAAAAASUVORK5CYII=

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -22,7 +22,7 @@ EOF
 ```
 
 ### Installing Operator Certification Operator
-* Use the left hand menu to navigate to *Operators*
+* Use the left-hand menu to navigate to *Operators*
 * In the *Operators* submenu click on *OperatorHub*
 * Use the Filter/Search box to filter on *Operator Certification Operator*
 * Click the *Operator Certification Operators* tile
@@ -31,18 +31,24 @@ EOF
 * Click the *View Operator* button
 
 ### Applying an Operator Pipeline Custom Resource
-* If you followed the last step of *View Operator*
+* In the *Project dropdown* select the *Project* you wish to apply the Custom Resource
 * Under *OP: Operator Pipeline* click *Create instance*
 * The *Create OperatorPipeline* screen should be pre-populated with default values
   * If the pre-installation steps were followed and all resource names are the same, nothing should need to be changed
 * Click *Create*
 * The CR will get created and the Operator will start reconciling
 
-### Check the Operator Logs
-* `oc get pods -n oco`
+### Check the Conditions of the Custom Resource
+* Click on the name of the Custom Resource you created above *operatorpipeline-sample*
+* Scroll down to the *Conditions* section
+* Validate that all *Status* values are *True*
+  * If a resource fails reconciliation the *Message* section should indicate what needs correction
+  
+### Optionally Check the Operator Logs
+* `oc get pods -n openshift-marketplace`
 * Copy the full pod name of the `certification-operator-controller-manager` pod
-* `oc get logs -f -n oco <pod name> manager`
-* Check to see if the recoincillation occured 
+* `oc get logs -f -n openshift-marketplace <pod name> manager`
+* Check to see if the reconciliation occurred 
 
 ## Uninstalling the Operator Pipeline Custom Resource
 * From the *Operator Certification Operator* main page 


### PR DESCRIPTION
- Pointing our readme to the certification release readme 
   - For optional resources
   - For running the pipeline
- Updating our CSV to be more human readable
   - This matches the readme minus the *Install* step  

Signed-off-by: Adam D. Cornett <adc@redhat.com>