### PR TITLE
adding in new flags to the OperatorPipelineSpec to determine what pipeline to install into the cluster when the CR is applied

### DIFF
--- a/api/v1alpha1/operatorpipeline_types.go
+++ b/api/v1alpha1/operatorpipeline_types.go
@@ -43,6 +43,21 @@ type OperatorPipelineSpec struct {
 
 	// The name of the secret containing the github ssh secret expected by the pipeline
 	GithubSSHSecretName string `json:"githubSSHSecretName,omitempty"`
+
+	// ApplyCIPipeline determines whether to install the ci pipeline.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="CI Pipeline",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+kubebuilder:validation:Required
+	ApplyCIPipeline bool `json:"applyCIPipeline"`
+
+	// ApplyHostedPipeline determines whether to install the hosted pipeline.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hosted Pipeline",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+kubebuilder:validation:Required
+	ApplyHostedPipeline bool `json:"applyHostedPipeline"`
+
+	// ApplyReleasePipeline determines whether to install the release pipeline.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Release Pipeline",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+kubebuilder:validation:Required
+	ApplyReleasePipeline bool `json:"applyReleasePipeline"`
 }
 
 // OperatorPipelineStatus defines the observed state of OperatorPipeline

--- a/bundle/manifests/certification.redhat.com_operatorpipelines.yaml
+++ b/bundle/manifests/certification.redhat.com_operatorpipelines.yaml
@@ -34,6 +34,18 @@ spec:
           spec:
             description: OperatorPipelineSpec defines the desired state of OperatorPipeline
             properties:
+              applyCIPipeline:
+                description: ApplyCIPipeline determines whether to install the ci
+                  pipeline.
+                type: boolean
+              applyHostedPipeline:
+                description: ApplyHostedPipeline determines whether to install the
+                  hosted pipeline.
+                type: boolean
+              applyReleasePipeline:
+                description: ApplyReleasePipeline determines whether to install the
+                  release pipeline.
+                type: boolean
               dockerRegistrySecretName:
                 description: The name of the secret containing the docker registry
                   credentials secret expected by the pipeline
@@ -58,6 +70,10 @@ spec:
                 description: The name of the secret containing the pyxis api secret
                   expected by the pipeline
                 type: string
+            required:
+            - applyCIPipeline
+            - applyHostedPipeline
+            - applyReleasePipeline
             type: object
           status:
             description: OperatorPipelineStatus defines the observed state of OperatorPipeline

--- a/bundle/manifests/operator-certification-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator-certification-operator.clusterserviceversion.yaml
@@ -11,6 +11,9 @@ metadata:
             "name": "operatorpipeline-sample"
           },
           "spec": {
+            "applyCIPipeline": true,
+            "applyHostedPipeline": false,
+            "applyReleasePipeline": false,
             "gitHubSecretName": "github-api-token",
             "kubeconfigSecretName": "kubeconfig",
             "operatorPipelinesRelease": "main",
@@ -36,6 +39,24 @@ spec:
       displayName: Operator Pipeline
       kind: OperatorPipeline
       name: operatorpipelines.certification.redhat.com
+      specDescriptors:
+      - description: ApplyCIPipeline determines whether to install the ci pipeline.
+        displayName: CI Pipeline
+        path: applyCIPipeline
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: ApplyHostedPipeline determines whether to install the hosted
+          pipeline.
+        displayName: Hosted Pipeline
+        path: applyHostedPipeline
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: ApplyReleasePipeline determines whether to install the release
+          pipeline.
+        displayName: Release Pipeline
+        path: applyReleasePipeline
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       version: v1alpha1
   description: |-
     A Kubernetes operator to provision resources for the operator certification pipeline. This operator is installed in all namespaces which can support multi-tenant scenarios. **Note:** This operator should only be used by Red Hat partners attempting to certify their operator(s).

--- a/config/crd/bases/certification.redhat.com_operatorpipelines.yaml
+++ b/config/crd/bases/certification.redhat.com_operatorpipelines.yaml
@@ -36,6 +36,18 @@ spec:
           spec:
             description: OperatorPipelineSpec defines the desired state of OperatorPipeline
             properties:
+              applyCIPipeline:
+                description: ApplyCIPipeline determines whether to install the ci
+                  pipeline.
+                type: boolean
+              applyHostedPipeline:
+                description: ApplyHostedPipeline determines whether to install the
+                  hosted pipeline.
+                type: boolean
+              applyReleasePipeline:
+                description: ApplyReleasePipeline determines whether to install the
+                  release pipeline.
+                type: boolean
               dockerRegistrySecretName:
                 description: The name of the secret containing the docker registry
                   credentials secret expected by the pipeline
@@ -60,6 +72,10 @@ spec:
                 description: The name of the secret containing the pyxis api secret
                   expected by the pipeline
                 type: string
+            required:
+            - applyCIPipeline
+            - applyHostedPipeline
+            - applyReleasePipeline
             type: object
           status:
             description: OperatorPipelineStatus defines the observed state of OperatorPipeline

--- a/config/manifests/bases/operator-certification-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/operator-certification-operator.clusterserviceversion.yaml
@@ -19,6 +19,24 @@ spec:
       displayName: Operator Pipeline
       kind: OperatorPipeline
       name: operatorpipelines.certification.redhat.com
+      specDescriptors:
+      - description: ApplyCIPipeline determines whether to install the ci pipeline.
+        displayName: CI Pipeline
+        path: applyCIPipeline
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: ApplyHostedPipeline determines whether to install the hosted
+          pipeline.
+        displayName: Hosted Pipeline
+        path: applyHostedPipeline
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: ApplyReleasePipeline determines whether to install the release
+          pipeline.
+        displayName: Release Pipeline
+        path: applyReleasePipeline
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       version: v1alpha1
   description: |-
     A Kubernetes operator to provision resources for the operator certification pipeline. This operator is installed in all namespaces which can support multi-tenant scenarios. **Note:** This operator should only be used by Red Hat partners attempting to certify their operator(s).

--- a/config/samples/certification_v1alpha1_operatorpipeline.yaml
+++ b/config/samples/certification_v1alpha1_operatorpipeline.yaml
@@ -7,3 +7,6 @@ spec:
   kubeconfigSecretName: "kubeconfig"
   gitHubSecretName: "github-api-token"
   pyxisSecretName: "pyxis-api-secret"
+  applyCIPipeline: true
+  applyHostedPipeline: false
+  applyReleasePipeline: false


### PR DESCRIPTION
- Fixes: #105 
- updated OperatorPipelineSpec to include boolean for each type of pipeline.
- added in xDescriptor markers so UI has a true/false toggle for easy usability of new boolean fields.
- added in a `deleteManifests` method to remove a given pipeline if a user changes the value from `true -> false` after a CR is applied.

Below are images of the UI
![image](https://user-images.githubusercontent.com/88156657/148986425-40865a6d-373d-4d93-bfa5-3eb6b36b2a76.png)

![image](https://user-images.githubusercontent.com/88156657/148986474-8fa78add-c49e-4d5a-8f44-3773d16bc893.png)



Signed-off-by: Adam D. Cornett <adc@redhat.com>