### PR TITLE
Use an emptyDir volume for git repo

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,12 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+        env:
+          - name: GIT_REPO_PATH
+            value: "/git"
+        volumeMounts:
+        - mountPath: /git
+          name: pipeline-clone-volume
         livenessProbe:
           httpGet:
             path: /healthz
@@ -53,5 +59,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      volumes:
+      - name: pipeline-clone-volume
+        emptyDir: {}
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/controllers/errors.go
+++ b/controllers/errors.go
@@ -6,3 +6,4 @@ import (
 
 var ErrSecretNotFound = errors.New("could not find existing secret")
 var ErrInvalidSecret = errors.New("the secret does not contain a valid key")
+var ErrGitRepoPathNotSpecified = errors.New("the GIT_REPO_PATH environment variable was not specified")

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -26,7 +26,8 @@ for local development, this dependency must be installed before *Testing Locally
 ## Testing Locally
 1. Have a cluster up and running
 2. Run `make install` to install `CRD's`
-3. Run `make run` to start the operator
+3. Export GIT_REPO_PATH. This path is used inside the operator container and goes not need to exist on the host. `export GIT_REPO_PATH=/git`
+4. Run `make run` to start the operator
    1. Or start the operator in your preferred manner
-4. Run `./docs/dev/seed.sh` to see all the configs/secrets in the cluster
+5. Run `./docs/dev/seed.sh` to see all the configs/secrets in the cluster
    1. Depending on what reconciler you are working on feel free to comment out anything in the file not related


### PR DESCRIPTION
This sets the operator up to only have a single reconcile of the git
repo, then any of the reconcilers (especially the status reconcile)
will be able to use the repo knowing that it's at the latest.

Signed-off-by: Brad P. Crochet <brad@redhat.com>