### PR TITLE
fixing issues with pipeline_dependencies and status

### DIFF
--- a/internal/reconcilers/pipeline_dependencies.go
+++ b/internal/reconcilers/pipeline_dependencies.go
@@ -95,7 +95,7 @@ func (r *PipelineDependenciesReconciler) applyOrDeletePipeline(ctx context.Conte
 	if applyManifest {
 		return r.applyManifests(ctx, yamlPath, pipeline, new(tekton.Pipeline))
 	}
-	return r.deleteManifests(ctx, filepath.Join(pipelineManifestsPath, operatorCIPipelineYml), pipeline, new(tekton.Pipeline))
+	return r.deleteManifests(ctx, yamlPath, pipeline, new(tekton.Pipeline))
 }
 
 func (r *PipelineDependenciesReconciler) applyManifests(ctx context.Context, fileName string, owner, obj client.Object) error {


### PR DESCRIPTION
With the introduction of sub-reconcilers for the dependencies and status, it seem we never fully tested this, and when a CR is applied the application error'd out.

### Changes
- Remove hardcoded path during deletion.
- Using `tekton.Pipeline` and `tekton.Task` instead of `client.Object` since we cannot marshal to this object, and this follow the patter elsewhere in the application.
- Creating arrays with a length of zero and a capacity of ten, otherwise length check of `array > 0` is always `true` and reconcile never completes successfully, even if there are no errors.
- Joining the filename with the `entity.Name()` since this value is just the filename, and not the full path plus filename.

### Testing
- Locally against a cluster
- Created a new controller, bundle and catalog images and deployed to a cluster

The UI now shows status properly and I see no exceptions thrown. However, due to how these sub-reconcilers currently work, there are alot of exceptions that are trapped and never bubble up to a log statement. Which is something we should look at fixing later.

![image](https://user-images.githubusercontent.com/88156657/165187928-6e217201-77ee-4db9-bcea-562c1c72d754.png)


Signed-off-by: Adam D. Cornett <adc@redhat.com>