### PR TITLE
updating openshift annotations to match our minKubeVersion of 1.21.0

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -16,7 +16,7 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 # OpenShift annotations.
-LABEL com.redhat.openshift.versions="v4.7-v4.10"
+LABEL com.redhat.openshift.versions="v4.8-v4.10"
 
 # Copy files to locations specified by labels.
 COPY bundle/manifests /manifests/

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -15,4 +15,4 @@ annotations:
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
   # OpenShift annotations.
-  com.redhat.openshift.versions: "v4.7-v4.10"
+  com.redhat.openshift.versions: "v4.8-v4.10"


### PR DESCRIPTION
- Since our `minKubeVersion` is `1.21.0` we were targeting an incorrect version of OpenShift which our operator would not run on. Updating this to match our bundle in `certified-operators`

Signed-off-by: Adam D. Cornett <adc@redhat.com>