### PR TITLE
Update Pipelines dependency to 1.7.1

### DIFF
--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -2,4 +2,4 @@ dependencies:
   - type: olm.package
     value:
       packageName: openshift-pipelines-operator-rh
-      version: "1.5.2"
+      version: "1.7.1"


### PR DESCRIPTION
Bump the Pipelines operator dependency to 1.7.1.

Signed-off-by: Brad P. Crochet <brad@redhat.com>