### PR TITLE
Build release on publish instead of tag

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,9 +1,12 @@
 name: Build Release
 
 on:
+  release:
+    types:
+      - published
   push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+    branches:
+      - ghactions
 
 jobs:
   build-release:


### PR DESCRIPTION
Match what preflight is doing for building releases. The release
workflow will trigger on the release being published, which will
support doing pre-release builds as well.

Signed-off-by: Brad P. Crochet <brad@redhat.com>