### PR TITLE
Switch the Dockerfile to use the correct version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY internal/ internal/
 COPY .git .git
 
 # Build
-RUN make build RELEASE_TAG=${release_tag}
+RUN make build VERSION=${release_tag}
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 


### PR DESCRIPTION
The RELEASE_TAG and VERSION vars in the Makefile were backwards. This
was fixed in a previous patch, but the Dockerfile was still referencing
RELEASE_TAG instead of VERSION.

Signed-off-by: Brad P. Crochet <brad@redhat.com>