### PR TITLE
updating release action to include 4.11

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -55,8 +55,8 @@ jobs:
     - name: Add OpenShift metadata to bundle
       id: add-openshift-metadata
       run: |
-        echo '  com.redhat.openshift.versions: "v4.8-v4.10"' >> bundle/annotations.yaml
-        echo 'LABEL com.redhat.openshift.versions="v4.8-v4.10"' >> bundle.Dockerfile
+        echo '  com.redhat.openshift.versions: "v4.8"' >> bundle/annotations.yaml
+        echo 'LABEL com.redhat.openshift.versions="v4.8"' >> bundle.Dockerfile
 
     - name: Build Bundle Image
       id: build-bundle-image


### PR DESCRIPTION
- Updating the release action to include 4.11

We need to cut a release, so that we can re-certify the operator for 4.11. If making this annotation open ended that is fine by me as well.

Signed-off-by: Adam D. Cornett <adc@redhat.com>