### PR TITLE
Adding a namespace to the example CR metadata

### DIFF
--- a/config/samples/certification_v1alpha1_operatorpipeline.yaml
+++ b/config/samples/certification_v1alpha1_operatorpipeline.yaml
@@ -2,6 +2,7 @@ apiVersion: certification.redhat.com/v1alpha1
 kind: OperatorPipeline
 metadata:
   name: operatorpipeline-sample
+  namespace: oco
 spec:
   operatorPipelinesRelease: main
   kubeconfigSecretName: "kubeconfig"


### PR DESCRIPTION
Enforce creating the example operand in the same namespace that includes the secrets and configs.
Fixes #146