### PR TITLE
adding logic to add owner reference to ImageStream

### DIFF
--- a/internal/reconcilers/certified_image_stream.go
+++ b/internal/reconcilers/certified_image_stream.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -44,6 +45,18 @@ func (r *CertifiedImageStreamReconciler) Reconcile(ctx context.Context, pipeline
 	stream := newImageStream(key)
 	if objects.IsObjectFound(ctx, r.Client, key, stream) {
 		log.Info("existing certified image stream found")
+
+		// setting owner reference on ImageStream CR, so CR gets garbage collected on OperatorPipeline deletion.
+		// ignoring error, since we do not need/want to requeue on this failure,
+		// and this should self correct on subsequent reconciles.
+		err := controllerutil.SetControllerReference(pipeline, stream, r.Scheme)
+		if err != nil {
+			log.Info("unable to set owner on certified image stream, "+
+				"this resource will need to be cleaned up manually on uninstall", "error", err.Error())
+			return false, nil
+		}
+		_ = r.Update(ctx, stream)
+
 		return false, nil // Existing ImageStream found, do nothing...
 	}
 


### PR DESCRIPTION
## Motivation
During some testing, I realized that we were never cleaning up the `ImageStream` CR, when an `OperatorPipeline` was deleted. After digging further, I found we were never setting the owner reference, (also we never really call `Create` for `ImageStream` directly, this is abstracted from since we only `Create` and `ImageStreamImport`).

## Change
Calling `SetControllerReference` which sets the `owner` reference properly, and calling update, when secondary reconciles happen.