### PR TITLE
adding call to pyxis for non EOL catalogs and updating imagestream logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/gomega v1.34.1
 	github.com/openshift/api v0.0.0-20240802200810-346347bccbc8
 	github.com/operator-framework/api v0.26.0
+	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466
 	github.com/tektoncd/pipeline v0.62.0
 	k8s.io/api v0.30.3
 	k8s.io/apimachinery v0.30.3

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,8 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 h1:17JxqqJY66GmZVHkmAsGEkcIu0oCe3AM420QDgGwZx0=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466/go.mod h1:9dIRpgIY7hVhoqfe0/FcYp0bpInZaT7dc3BYOprrIUE=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/internal/pyxis/pyxis.go
+++ b/internal/pyxis/pyxis.go
@@ -1,0 +1,72 @@
+package pyxis
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/shurcooL/graphql"
+)
+
+const (
+	DefaultPyxisHost = "catalog.redhat.com/api/containers"
+)
+
+type PyxisClient struct {
+	Client    *http.Client
+	PyxisHost string
+}
+
+func (p *PyxisClient) getPyxisGraphqlURL() string {
+	return fmt.Sprintf("https://%s/graphql/", p.PyxisHost)
+}
+
+func NewPyxisClient(pyxisHost string, httpClient *http.Client) *PyxisClient {
+	return &PyxisClient{
+		Client:    httpClient,
+		PyxisHost: pyxisHost,
+	}
+}
+
+func (p *PyxisClient) FindOperatorIndices(ctx context.Context, organization string) ([]OperatorIndex, error) {
+	// our graphQL query
+	var query struct {
+		FindOperatorIndices struct {
+			OperatorIndex []struct {
+				OCPVersion   graphql.String `graphql:"ocp_version"`
+				Organization graphql.String `graphql:"organization"`
+				EndOfLife    graphql.String `graphql:"end_of_life"`
+			} `graphql:"data"`
+			Errors struct {
+				Status graphql.Int    `graphql:"status"`
+				Detail graphql.String `graphql:"detail"`
+			} `graphql:"error"`
+			Total graphql.Int
+			Page  graphql.Int
+			// filter to make sure we get exact results, end_of_life is a string, querying for `null` yields active OCP versions.
+		} `graphql:"find_operator_indices(filter:{and:[{organization:{eq:$organization}},{end_of_life:{eq:null}}]})"`
+	}
+
+	// variables to feed to our graphql filter
+	variables := map[string]interface{}{
+		"organization": graphql.String(organization),
+	}
+
+	// make our query
+	client := graphql.NewClient(p.getPyxisGraphqlURL(), p.Client)
+
+	err := client.Query(ctx, &query, variables)
+	if err != nil {
+		return nil, fmt.Errorf("error while executing remote query for %s catalogs: %v", organization, err)
+	}
+
+	operatorIndices := make([]OperatorIndex, len(query.FindOperatorIndices.OperatorIndex))
+	for idx, operator := range query.FindOperatorIndices.OperatorIndex {
+		operatorIndices[idx] = OperatorIndex{
+			OCPVersion:   string(operator.OCPVersion),
+			Organization: string(operator.Organization),
+		}
+	}
+
+	return operatorIndices, nil
+}

--- a/internal/pyxis/types.go
+++ b/internal/pyxis/types.go
@@ -1,0 +1,7 @@
+package pyxis
+
+type OperatorIndex struct {
+	OCPVersion   string `json:"ocp_version"`
+	Organization string `json:"organization"`
+	EndOfLife    string `json:"end_of_life,omitempty"`
+}


### PR DESCRIPTION
## Motivation
The old logic we have in place was trying to mirror `all` of the tags within a given `namespace/image`, and since there are about ~4k tags at this point, our logic would timeout and not create an ImageStream. This could cause us to be stuck on these sub-reconcilers, until a user manually added the imagestreams with the tags that they cared about.

- Fixes: #154

## Implementation
For the implementation, a graphql client for pyxis was added and a query that looks for non End Of Life catalogs. For the implementation of the query we can look for OCP versions where `eol equals null`.

### Sample GraphQL Query
```
query:
{
  find_operator_indices(
    filter: {
      and : [
        {
          organization: {
            eq: "redhat-marketplace"
          }
        },
        {
          end_of_life: {
            eq: null
          }
        }
      ]
    }
  ) {
    data{
      ocp_version
      organization
      end_of_life
      }
    error {
      status
      detail
    }
  }
}

results:
{
  "data": {
    "find_operator_indices": {
      "data": [
        {
          "ocp_version": "4.12",
          "organization": "redhat-marketplace",
          "end_of_life": null
        },
        {
          "ocp_version": "4.13",
          "organization": "redhat-marketplace",
          "end_of_life": null
        },
        {
          "ocp_version": "4.14",
          "organization": "redhat-marketplace",
          "end_of_life": null
        },
        {
          "ocp_version": "4.15",
          "organization": "redhat-marketplace",
          "end_of_life": null
        },
        {
          "ocp_version": "4.16",
          "organization": "redhat-marketplace",
          "end_of_life": null
        },
        {
          "ocp_version": "4.17",
          "organization": "redhat-marketplace",
          "end_of_life": null
        }
      ],
      "error": null
    }
  }
}
```


## Testing
This was tested in a cluster both as a catalog/bundle and also running locally in debug mode. 

```
oc get is
NAME                       IMAGE REPOSITORY                                                                       TAGS                                  UPDATED
certified-operator-index   default-route-openshift-image-registry.apps-crc.testing/oco/certified-operator-index   v4.12,v4.13,v4.14,v4.15,v4.16,v4.17   27 minutes ago
redhat-marketplace-index   default-route-openshift-image-registry.apps-crc.testing/oco/redhat-marketplace-index   v4.12,v4.13,v4.14,v4.15,v4.16,v4.17   27 minutes ago
```

As you can see we only get the tags for catalogs which are not EOL.