### PR TITLE
Update lint to use golangci-lint v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,71 +1,89 @@
+version: "2"
 run:
-  # Default timeout is 1m, up to give more room
+  # Default timeout is 0 (no limit), have an upper limit
   timeout: 4m
-
-linters:
-  enable:
-  - asciicheck
-  - gofumpt
-  - goimports
-  - importas
-  - ginkgolinter
-  - prealloc
-  - revive
-  - misspell
-  - stylecheck
-  - tparallel
-  - unconvert
-  - unparam
-  - unused
-  - whitespace
-
-linters-settings:
-  importas:
-    alias:
-    - pkg: k8s.io/api/core/v1
-      alias: corev1
-    - pkg: k8s.io/api/rbac/v1
-      alias: rbacv1
-    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-      alias: metav1
-    - pkg: k8s.io/apimachinery/pkg/api/errors
-      alias: apierrors
-    - pkg: sigs.k8s.io/controller-runtime
-      alias: ctrl
-    - pkg: sigs.k8s.io/controller-runtime/pkg/log
-      alias: logf
-    - pkg: k8s.io/apimachinery/pkg/util/runtime
-      alias: utilruntime
-    - pkg: k8s.io/client-go/kubernetes/scheme
-      alias: clientgoscheme
-    - pkg: k8s.io/apimachinery/pkg/util/yaml
-      alias: yamlutil
-    - pkg: github.com/operator-framework/api/pkg/operators/v1alpha1
-      alias: operatorsv1a1
-    - pkg: github.com/openshift/api/image/v1
-      alias: imagev1
-    - pkg: github.com/openshift/api/security/v1
-      alias: securityv1
-    - pkg: github.com/tektoncd/pipeline/pkg/apis/pipeline/v1
-      alias: tekton
-    - pkg: github.com/redhat-openshift-ecosystem/operator-certification-operator/api/v1alpha1
-      alias: certv1alpha1
-
-  revive:
-    rules:
-    - name: dot-imports
-      severity: warning
-      disabled: true
-    - name: comment-spacings
-
-  stylecheck:
-    dot-import-whitelist:
-      - github.com/onsi/gomega
-      - github.com/onsi/ginkgo
-      - github.com/onsi/ginkgo/v2
-  goimports:
-    local-prefixes: github.com/redhat-openshift-ecosystem/operator-certification-operator
-
 output:
   formats:
-    - format: tab
+    tab:
+      path: stdout
+      colors: false
+linters:
+  enable:
+    - asciicheck
+    - ginkgolinter
+    - importas
+    - misspell
+    - prealloc
+    - revive
+    - staticcheck
+    - tparallel
+    - unconvert
+    - unparam
+    - whitespace
+  settings:
+    importas:
+      alias:
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/api/rbac/v1
+          alias: rbacv1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: sigs.k8s.io/controller-runtime
+          alias: ctrl
+        - pkg: sigs.k8s.io/controller-runtime/pkg/log
+          alias: logf
+        - pkg: k8s.io/apimachinery/pkg/util/runtime
+          alias: utilruntime
+        - pkg: k8s.io/client-go/kubernetes/scheme
+          alias: clientgoscheme
+        - pkg: k8s.io/apimachinery/pkg/util/yaml
+          alias: yamlutil
+        - pkg: github.com/operator-framework/api/pkg/operators/v1alpha1
+          alias: operatorsv1a1
+        - pkg: github.com/openshift/api/image/v1
+          alias: imagev1
+        - pkg: github.com/openshift/api/security/v1
+          alias: securityv1
+        - pkg: github.com/tektoncd/pipeline/pkg/apis/pipeline/v1
+          alias: tekton
+        - pkg: github.com/redhat-openshift-ecosystem/operator-certification-operator/api/v1alpha1
+          alias: certv1alpha1
+    revive:
+      rules:
+        - name: dot-imports
+          severity: warning
+          disabled: true
+        - name: comment-spacings
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/onsi/gomega
+        - github.com/onsi/ginkgo
+        - github.com/onsi/ginkgo/v2
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/redhat-openshift-ecosystem/operator-certification-operator
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -298,10 +298,10 @@ tidy:
 	git diff --exit-code
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v2.1.6
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT):
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/internal/controller/operatorpipeline_controller.go
+++ b/internal/controller/operatorpipeline_controller.go
@@ -63,7 +63,7 @@ func (r *OperatorPipelineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	reqLogger.Info("Reconciling OperatorPipeline")
 
 	currentPipeline := &v1alpha1.OperatorPipeline{}
-	err := r.Client.Get(ctx, req.NamespacedName, currentPipeline)
+	err := r.Get(ctx, req.NamespacedName, currentPipeline)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request. Return and don't
@@ -83,7 +83,7 @@ func (r *OperatorPipelineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			// creating listOptions inorder to know the number of OperatorPipeline resources in the given namespace
 			// if last CR in namespace we can remove the ClusterRoleBinding associated with the namespace
 			listOptions := client.InNamespace(currentPipeline.Namespace)
-			if err := r.Client.List(ctx, namespacePipelines, listOptions); err != nil {
+			if err := r.List(ctx, namespacePipelines, listOptions); err != nil {
 				return ctrl.Result{}, err
 			}
 
@@ -98,7 +98,7 @@ func (r *OperatorPipelineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			clusterPipelines := &v1alpha1.OperatorPipelineList{}
 			// not creating listOptions since we want to know the total number of OperatorPipelines in the entire cluster
 			// if last CR in cluster we can remove the SCC and ClusterRole
-			if err := r.Client.List(ctx, clusterPipelines); err != nil {
+			if err := r.List(ctx, clusterPipelines); err != nil {
 				return ctrl.Result{}, err
 			}
 
@@ -161,23 +161,23 @@ func (r *OperatorPipelineReconciler) deleteSCCandClusterRole(ctx context.Context
 	}
 
 	crList := &rbacv1.ClusterRoleList{}
-	if err := r.Client.List(ctx, crList, listOption); err != nil {
+	if err := r.List(ctx, crList, listOption); err != nil {
 		return err
 	}
 
 	for _, cr := range crList.Items {
-		if err := r.Client.Delete(ctx, &cr); err != nil {
+		if err := r.Delete(ctx, &cr); err != nil {
 			return err
 		}
 	}
 
 	sccList := &securityv1.SecurityContextConstraintsList{}
-	if err := r.Client.List(ctx, sccList, listOption); err != nil {
+	if err := r.List(ctx, sccList, listOption); err != nil {
 		return err
 	}
 
 	for _, scc := range sccList.Items {
-		if err := r.Client.Delete(ctx, &scc); err != nil {
+		if err := r.Delete(ctx, &scc); err != nil {
 			return err
 		}
 	}
@@ -194,12 +194,12 @@ func (r *OperatorPipelineReconciler) deleteClusterRoleBinding(ctx context.Contex
 	}
 
 	crbList := &rbacv1.ClusterRoleBindingList{}
-	if err := r.Client.List(ctx, crbList, listOption); err != nil {
+	if err := r.List(ctx, crbList, listOption); err != nil {
 		return err
 	}
 
 	for _, crb := range crbList.Items {
-		if err := r.Client.Delete(ctx, &crb); err != nil {
+		if err := r.Delete(ctx, &crb); err != nil {
 			return err
 		}
 	}

--- a/internal/reconcilers/certified_image_stream.go
+++ b/internal/reconcilers/certified_image_stream.go
@@ -97,7 +97,7 @@ func (r *CertifiedImageStreamReconciler) Reconcile(ctx context.Context, pipeline
 	imgImport.Spec.Images = imageSpecs
 
 	log.Info("creating new certified image stream import")
-	if err := r.Client.Create(ctx, imgImport); err != nil {
+	if err := r.Create(ctx, imgImport); err != nil {
 		return true, err
 	}
 

--- a/internal/reconcilers/marketplace_image_stream.go
+++ b/internal/reconcilers/marketplace_image_stream.go
@@ -96,7 +96,7 @@ func (r *MarketplaceImageStreamReconciler) Reconcile(ctx context.Context, pipeli
 	imgImport.Spec.Images = imageSpecs
 
 	log.Info("creating new marketplace image stream import")
-	if err := r.Client.Create(ctx, imgImport); err != nil {
+	if err := r.Create(ctx, imgImport); err != nil {
 		return true, err
 	}
 

--- a/internal/reconcilers/pipeline_dependencies.go
+++ b/internal/reconcilers/pipeline_dependencies.go
@@ -155,10 +155,10 @@ func (r *PipelineDependenciesReconciler) applyManifests(ctx context.Context, fil
 	}
 
 	obj.SetNamespace(owner.GetNamespace())
-	err = r.Client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
+	err = r.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
 
 	if len(obj.GetUID()) > 0 {
-		if err := r.Client.Update(ctx, obj); err != nil {
+		if err := r.Update(ctx, obj); err != nil {
 			log.Error(err, fmt.Sprintf("failed to update pipeline resource for file: %s", fileName))
 			return err
 		}
@@ -169,7 +169,7 @@ func (r *PipelineDependenciesReconciler) applyManifests(ctx context.Context, fil
 			return err
 		}
 		_ = controllerutil.SetControllerReference(owner, obj, r.Scheme)
-		if err := r.Client.Create(ctx, obj); err != nil {
+		if err := r.Create(ctx, obj); err != nil {
 			log.Error(err, fmt.Sprintf("failed to create pipeline resource for file: %s", fileName))
 			return err
 		}
@@ -192,13 +192,13 @@ func (r *PipelineDependenciesReconciler) deleteManifests(ctx context.Context, fi
 	}
 
 	obj.SetNamespace(owner.GetNamespace())
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil && !errors.IsNotFound(err) {
+	if err := r.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil && !errors.IsNotFound(err) {
 		return err
 	} else if errors.IsNotFound(err) {
 		return nil
 	}
 
-	if err := r.Client.Delete(ctx, obj); err != nil {
+	if err := r.Delete(ctx, obj); err != nil {
 		log.Error(err, fmt.Sprintf("failed to delete pipeline resource for file: %s", fileName))
 		return err
 	}

--- a/internal/reconcilers/status.go
+++ b/internal/reconcilers/status.go
@@ -194,7 +194,7 @@ func (r *StatusReconciler) reconcileImageStreamStatus(ctx context.Context, pipel
 	log := r.Log.WithValues("status.observedGeneration", pipeline.Generation)
 
 	imageStream := &imagev1.ImageStream{}
-	err := r.Client.Get(ctx, types.NamespacedName{Namespace: pipeline.Namespace, Name: indexName}, imageStream)
+	err := r.Get(ctx, types.NamespacedName{Namespace: pipeline.Namespace, Name: indexName}, imageStream)
 	if err != nil && !apierrors.IsNotFound(err) {
 		log.WithValues("imagestream", types.NamespacedName{Namespace: pipeline.Namespace, Name: indexName}).
 			Error(err, "failed to get object")
@@ -227,7 +227,7 @@ func (r *StatusReconciler) reconcileSecretStatus(ctx context.Context, pipeline *
 	}
 	log := r.Log.WithValues("status.observedGeneration", pipeline.Generation)
 	secret := &corev1.Secret{}
-	err := r.Client.Get(ctx, types.NamespacedName{Namespace: pipeline.Namespace, Name: secretName}, secret)
+	err := r.Get(ctx, types.NamespacedName{Namespace: pipeline.Namespace, Name: secretName}, secret)
 	if err != nil && !apierrors.IsNotFound(err) {
 		log.WithValues(strings.ToLower(secretType), types.NamespacedName{Namespace: pipeline.Namespace, Name: secretName}).
 			Error(err, "failed to get object")
@@ -367,8 +367,8 @@ func (r *StatusReconciler) reconcilePipelineStatus(ctx context.Context, pipeline
 		return true, err
 	}
 
-	obj.SetNamespace(pipeline.ObjectMeta.Namespace)
-	err = r.Client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
+	obj.SetNamespace(pipeline.Namespace)
+	err = r.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
 	if err != nil {
 		meta.SetStatusCondition(&pipeline.Status.Conditions, r.setStatusInfo(
 			r.conditionStatus(false),
@@ -434,8 +434,8 @@ func (r *StatusReconciler) reconcileTasksStatus(ctx context.Context, pipeline *v
 			unmarshalErrors = append(unmarshalErrors, entry.Name())
 			continue
 		}
-		obj.SetNamespace(pipeline.ObjectMeta.Namespace)
-		err = r.Client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
+		obj.SetNamespace(pipeline.Namespace)
+		err = r.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
 		if err != nil && apierrors.IsNotFound(err) {
 			getErrors = append(getErrors, obj.GetName())
 			continue


### PR DESCRIPTION
- Update Makefile to get and use golangci-lint v2
- Update .golangci-lint.yaml file to match v2 config file format
- Address/ignore findings raised by staticcheck