### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -7,21 +7,26 @@ on:
 jobs:
   build-main:
     name: Build and push a main snapshot image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
       id: go
-    - name: Fetch latest release version
-      uses: reloc8/action-latest-release-version@1.0.0
-      id: fetch-latest-release
-    - name: Set Env Tags
-      run: echo RELEASE_TAG=${{ steps.fetch-latest-release.outputs.latest-release }}-alpha >> $GITHUB_ENV
-    - name: Set a default if release tag is empty
-      if: ${{ steps.fetch-latest-release.outputs.latest-release }} == ""
-      run: echo RELEASE_TAG=0.0.0 >> $GITHUB_ENV
+
+    - name: Set release version
+      run: |
+        RELEASE_TAG=$(gh --repo "${GITHUB_REPOSITORY}" release list \
+                         --json name,isLatest \
+                         --jq '.[] | select(.isLatest) | .name')
+        if [ -z "${RELEASE_TAG}" ]; then
+          RELEASE_TAG="0.0.0"
+        fi
+        echo "RELEASE_TAG=${RELEASE_TAG}" | tee -a "${GITHUB_ENV}"
+      env:
+        GH_TOKEN: ${{ github.token }}
+
     - name: Set image registry env
       run: |
         echo IMAGE_REGISTRY=$(echo ${{ secrets.IMAGE_REGISTRY }} | cut -d '/' -f 1) >> $GITHUB_ENV

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   build-release:
     name: Build and push a tag image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
       id: go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ on:
 jobs:
   sanity:
     name: sanity
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
       id: go


### PR DESCRIPTION
- Update the versions of `actions/checkout` and `actions/setup-go` which are used
- Use `ubuntu-latest` instead of specific versions (only pin if there's an actual need to stay on a specific version)
- Replace the usage of third-party action [`reloc8/action-latest-release-version`](https://github.com/reloc8/action-latest-release-version) with `gh` CLI invocation. The replaced action works by fetching all tags in the cloned repo and getting the latest one; the `gh` CLI works instead by querying the GitHub API.