### PR TITLE
increase request/limit memory/cpu to account for additional overhead

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -61,11 +61,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 200m
-            memory: 100Mi
+            cpu: 500m
+            memory: 256Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 128Mi
       volumes:
       - name: pipeline-clone-volume
         emptyDir: {}


### PR DESCRIPTION
## Motivation
When testing some changes on various versions of OCP, I noticed that the `manager` pod was getting `OOMKilled` on some clusters and some versions of OCP. After looking into it more, we used to have a `kube-rbac-proxy` sidecar that was handling RBAC/etc, and had it's own `memory` configuration. When we took away the `proxy`, this means that the `manager` is now doing that lifting, but we never increased the memory or cpu.

### Sidecar Config
https://github.com/redhat-openshift-ecosystem/operator-certification-operator/blob/e98c4427480e78358163f25221fe7920450aa59f/config/default/manager_auth_proxy_patch.yaml#L24-L29

### Manager Config
https://github.com/redhat-openshift-ecosystem/operator-certification-operator/blob/96b8ee4089b272811e6ee00804259ed200b25794/config/manager/manager.yaml#L62-L68

## Changes
Increase memory/cpu to be close to the additive values of when we had two containers (proxy + manager),  for the manager container.