### PR TITLE
Add initial dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# dependabot config
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This should cover just the GitHub Actions usage for now. Leaving Golang modules out for now since those updates need to be scheduled/timed specifically.