### PR TITLE
Harden and pin GHA actions by digest

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -9,9 +9,13 @@ jobs:
     name: Build and push a main snapshot image
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-go@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
+        persist-credentials: false
+    
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        cache: false
         go-version-file: go.mod
       id: go
 
@@ -34,7 +38,7 @@ jobs:
 
     - name: Build Operator Image
       id: build-operator-image
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
       with:
         image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/operator-certification-operator
         tags: ${{ github.sha }} latest
@@ -46,7 +50,7 @@ jobs:
 
     - name: Push Operator Image
       id: push-operator-image
-      uses: redhat-actions/push-to-registry@v2
+      uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
       with:
         image: operator-certification-operator
         tags: ${{ steps.build-operator-image.outputs.tags }}
@@ -65,7 +69,7 @@ jobs:
 
     - name: Build Bundle Image
       id: build-bundle-image
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
       with:
         image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/operator-certification-operator-bundle
         tags: latest
@@ -74,7 +78,7 @@ jobs:
 
     - name: Push Bundle Image
       id: push-bundle-image
-      uses: redhat-actions/push-to-registry@v2
+      uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
       with:
         image: operator-certification-operator-bundle
         tags: ${{ steps.build-bundle-image.outputs.tags }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,9 +13,13 @@ jobs:
     name: Build and push a tag image
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-go@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
+        persist-credentials: false
+
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        cache: false
         go-version-file: go.mod
       id: go
     - name: Set Env Tags
@@ -26,7 +30,7 @@ jobs:
 
     - name: Build Operator Image
       id: build-operator-image
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
       with:
         image: ${{ secrets.IMAGE_REGISTRY }}/operator-certification-operator
         tags: ${{ env.RELEASE_TAG }}
@@ -37,7 +41,7 @@ jobs:
 
     - name: Push Operator Image
       id: push-operator-image
-      uses: redhat-actions/push-to-registry@v2
+      uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
       with:
         image: operator-certification-operator
         tags: ${{ steps.build-operator-image.outputs.tags }}
@@ -64,7 +68,7 @@ jobs:
 
     - name: Build Bundle Image
       id: build-bundle-image
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
       with:
         image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/operator-certification-operator-bundle
         tags: ${{ env.RELEASE_TAG }}
@@ -73,7 +77,7 @@ jobs:
 
     - name: Push Bundle Image
       id: push-bundle-image
-      uses: redhat-actions/push-to-registry@v2
+      uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
       with:
         image: operator-certification-operator-bundle
         tags: ${{ steps.build-bundle-image.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,14 @@ jobs:
     name: sanity
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v6
+        persist-credentials: false
+
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
+        cache: false
         go-version-file: go.mod
       id: go
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI and build workflows updated to pin GitHub Actions and helper actions to specific commit SHAs (removing floating major tags).
  * Pinned versions: actions/checkout v6.0.3, actions/setup-go v6.4.0, redhat-actions/buildah-build v2.13, redhat-actions/push-to-registry v2.8.
  * Pinning applied across continuous integration, main build, and release build pipelines to stabilize reproducible builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->