### PR TITLE
fix(ci): align buildah-build image tag with push-to-registry

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -45,7 +45,7 @@ jobs:
       id: build-operator-image
       uses: redhat-actions/buildah-build@3a51aade9afa17e5c78256bcbe2e1ee08c7b995b # v3.0.2
       with:
-        image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/operator-certification-operator
+        image: operator-certification-operator
         tags: ${{ github.sha }} latest
         build-args: |
           quay_expiration=1w
@@ -73,7 +73,7 @@ jobs:
       id: build-bundle-image
       uses: redhat-actions/buildah-build@3a51aade9afa17e5c78256bcbe2e1ee08c7b995b # v3.0.2
       with:
-        image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/operator-certification-operator-bundle
+        image: operator-certification-operator-bundle
         tags: latest
         dockerfiles: |
           ./bundle.Dockerfile

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -39,7 +39,7 @@ jobs:
       id: build-operator-image
       uses: redhat-actions/buildah-build@3a51aade9afa17e5c78256bcbe2e1ee08c7b995b # v3.0.2
       with:
-        image: ${{ secrets.IMAGE_REGISTRY }}/operator-certification-operator
+        image: operator-certification-operator
         tags: ${{ env.RELEASE_TAG }}
         build-args: |
           release_tag=${{ env.RELEASE_TAG }}
@@ -74,7 +74,7 @@ jobs:
       id: build-bundle-image
       uses: redhat-actions/buildah-build@3a51aade9afa17e5c78256bcbe2e1ee08c7b995b # v3.0.2
       with:
-        image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/operator-certification-operator-bundle
+        image: operator-certification-operator-bundle
         tags: ${{ env.RELEASE_TAG }}
         dockerfiles: |
           ./bundle.Dockerfile


### PR DESCRIPTION
push-to-registry v3.0.0 now requires the local image to be reachable as `localhost/<image>`, but buildah-build was tagging it with the full registry-qualified name. Use the bare image name in both build steps so the push step can find the image to push.

- Relates: #190 
- Failed Action: https://github.com/redhat-openshift-ecosystem/operator-certification-operator/actions/runs/30842548469/job/91782901900


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release and main build workflows so container images are built with local names and correctly tagged when pushed to the configured registry.
  * Reduced the risk of image naming and publishing issues during automated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->